### PR TITLE
fixed install: versioneer overrides custom_build_ext, and if gcc is n…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ setup(
     python_requires=">=3.7",
     extras_require={"hiredis": ["hiredis>=0.2.0"]},
     tests_require=["pytest", "pytest_asyncio>=0.5.0"],
-    cmdclass={"test": PyTest, "build_ext": custom_build_ext, ** versioneer.get_cmdclass()},
+    cmdclass=versioneer.get_cmdclass({"test": PyTest, "build_ext": custom_build_ext}),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
versioneer overrides custom_build_ext, and if gcc is not found, an exception occurs, not a warning

## Description
see https://github.com/python-versioneer/python-versioneer/blob/master/src/cmdclass.py#L95