### PR TITLE
Blocking cluster connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ pip install coredis
 - [Sentinel](https://coredis.readthedocs.org/en/latest/api.html#sentinel)
 
 ### Application patterns
+- [Connection Pooling](https://coredis.readthedocs.org/en/latest/handbook/connections.html#connection-pools)
 - [PubSub](https://coredis.readthedocs.org/en/latest/handbook/pubsub.html)
 - [Sharded PubSub](https://coredis.readthedocs.org/en/latest/handbook/pubsub.html#sharded-pub-sub) [`>= Redis 7.0`]
 - [Stream Consumers](https://coredis.readthedocs.org/en/latest/handbook/streams.html)

--- a/coredis/__init__.py
+++ b/coredis/__init__.py
@@ -15,7 +15,12 @@ from coredis.connection import (
     Connection,
     UnixDomainSocketConnection,
 )
-from coredis.pool import BlockingConnectionPool, ClusterConnectionPool, ConnectionPool
+from coredis.pool import (
+    BlockingClusterConnectionPool,
+    BlockingConnectionPool,
+    ClusterConnectionPool,
+    ConnectionPool,
+)
 from coredis.tokens import PureToken
 
 from . import _version
@@ -31,6 +36,7 @@ __all__ = [
     "ClusterConnection",
     "BlockingConnectionPool",
     "ConnectionPool",
+    "BlockingClusterConnectionPool",
     "ClusterConnectionPool",
     "PureToken",
 ]

--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -402,6 +402,7 @@ class Redis(Client[AnyStr]):
         stream_timeout: Optional[int] = ...,
         connect_timeout: Optional[int] = ...,
         connection_pool: Optional[ConnectionPool] = ...,
+        connection_pool_cls: Type[ConnectionPool] = ...,
         unix_socket_path: Optional[str] = ...,
         encoding: str = ...,
         decode_responses: Literal[False] = ...,
@@ -437,6 +438,7 @@ class Redis(Client[AnyStr]):
         stream_timeout: Optional[int] = ...,
         connect_timeout: Optional[int] = ...,
         connection_pool: Optional[ConnectionPool] = ...,
+        connection_pool_cls: Type[ConnectionPool] = ...,
         unix_socket_path: Optional[str] = ...,
         encoding: str = ...,
         decode_responses: Literal[True],
@@ -471,6 +473,7 @@ class Redis(Client[AnyStr]):
         stream_timeout: Optional[int] = None,
         connect_timeout: Optional[int] = None,
         connection_pool: Optional[ConnectionPool] = None,
+        connection_pool_cls: Type[ConnectionPool] = ConnectionPool,
         unix_socket_path: Optional[str] = None,
         encoding: str = "utf-8",
         decode_responses: bool = False,
@@ -494,6 +497,8 @@ class Redis(Client[AnyStr]):
     ) -> None:
         """
         Changes
+          - .. versionadded:: 4.3.0
+             Added :paramref:`connection_pool_cls`
           - .. versionchanged:: 4.0.0
 
             - :paramref:`non_atomic_cross_slot` defaults to ``True``
@@ -521,6 +526,8 @@ class Redis(Client[AnyStr]):
         :param connect_timeout: Timeout for establishing a connection to the server
         :param connection_pool: The connection pool instance to use. If not provided
          a new pool will be assigned to this client.
+        :param connection_pool_cls: The connection pool class to use when constructing
+         a connection pool for this instance.
         :param unix_socket_path: Path to the UDS which the redis server
          is listening at
         :param encoding: The codec to use to encode strings transmitted to redis
@@ -574,7 +581,7 @@ class Redis(Client[AnyStr]):
             stream_timeout=stream_timeout,
             connect_timeout=connect_timeout,
             connection_pool=connection_pool,
-            connection_pool_cls=ConnectionPool,
+            connection_pool_cls=connection_pool_cls,
             unix_socket_path=unix_socket_path,
             encoding=encoding,
             decode_responses=decode_responses,

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -161,6 +161,7 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = ...,
         ssl_check_hostname: Optional[bool] = ...,
         ssl_ca_certs: Optional[str] = ...,
+        blocking: bool = ...,
         max_connections: int = ...,
         max_connections_per_node: bool = ...,
         readonly: bool = ...,
@@ -192,6 +193,7 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = ...,
         ssl_check_hostname: Optional[bool] = ...,
         ssl_ca_certs: Optional[str] = ...,
+        blocking: bool = ...,
         max_connections: int = ...,
         max_connections_per_node: bool = ...,
         readonly: bool = ...,
@@ -222,6 +224,7 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = None,
         ssl_check_hostname: Optional[bool] = None,
         ssl_ca_certs: Optional[str] = None,
+        blocking: bool = False,
         max_connections: int = 32,
         max_connections_per_node: bool = False,
         readonly: bool = False,
@@ -240,6 +243,8 @@ class RedisCluster(
         """
 
         Changes
+          - .. versionadded:: 4.3.0
+            :paramref:`blocking`
           - .. versionchanged:: 4.0.0
             :paramref:`non_atomic_cross_slot` defaults to ``True``
             :paramref:`protocol_version`` defaults to ``3``
@@ -347,6 +352,7 @@ class RedisCluster(
 
             pool = ClusterConnectionPool(
                 startup_nodes=startup_nodes,
+                blocking=blocking,
                 max_connections=max_connections,
                 reinitialize_steps=reinitialize_steps,
                 max_connections_per_node=max_connections_per_node,

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -161,7 +161,6 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = ...,
         ssl_check_hostname: Optional[bool] = ...,
         ssl_ca_certs: Optional[str] = ...,
-        blocking: bool = ...,
         max_connections: int = ...,
         max_connections_per_node: bool = ...,
         readonly: bool = ...,
@@ -170,6 +169,7 @@ class RedisCluster(
         nodemanager_follow_cluster: bool = ...,
         decode_responses: Literal[False] = ...,
         connection_pool: Optional[ClusterConnectionPool] = ...,
+        connection_pool_cls: Type[ClusterConnectionPool] = ...,
         protocol_version: Literal[2, 3] = ...,
         verify_version: bool = ...,
         non_atomic_cross_slot: bool = ...,
@@ -193,7 +193,6 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = ...,
         ssl_check_hostname: Optional[bool] = ...,
         ssl_ca_certs: Optional[str] = ...,
-        blocking: bool = ...,
         max_connections: int = ...,
         max_connections_per_node: bool = ...,
         readonly: bool = ...,
@@ -202,6 +201,7 @@ class RedisCluster(
         nodemanager_follow_cluster: bool = ...,
         decode_responses: Literal[True],
         connection_pool: Optional[ClusterConnectionPool] = ...,
+        connection_pool_cls: Type[ClusterConnectionPool] = ...,
         protocol_version: Literal[2, 3] = ...,
         verify_version: bool = ...,
         non_atomic_cross_slot: bool = ...,
@@ -224,7 +224,6 @@ class RedisCluster(
         ssl_cert_reqs: Optional[Literal["optional", "required", "none"]] = None,
         ssl_check_hostname: Optional[bool] = None,
         ssl_ca_certs: Optional[str] = None,
-        blocking: bool = False,
         max_connections: int = 32,
         max_connections_per_node: bool = False,
         readonly: bool = False,
@@ -233,6 +232,7 @@ class RedisCluster(
         nodemanager_follow_cluster: bool = False,
         decode_responses: bool = False,
         connection_pool: Optional[ClusterConnectionPool] = None,
+        connection_pool_cls: Type[ClusterConnectionPool] = ClusterConnectionPool,
         protocol_version: Literal[2, 3] = 3,
         verify_version: bool = True,
         non_atomic_cross_slot: bool = True,
@@ -244,7 +244,7 @@ class RedisCluster(
 
         Changes
           - .. versionadded:: 4.3.0
-            :paramref:`blocking`
+            Added :paramref:`connection_pool_cls`
           - .. versionchanged:: 4.0.0
             :paramref:`non_atomic_cross_slot` defaults to ``True``
             :paramref:`protocol_version`` defaults to ``3``
@@ -298,6 +298,8 @@ class RedisCluster(
          (See :ref:`handbook/encoding:encoding/decoding`)
         :param connection_pool: The connection pool instance to use. If not provided
          a new pool will be assigned to this client.
+        :param connection_pool_cls: The connection pool class to use when constructing
+         a connection pool for this instance.
         :param protocol_version: Whether to use the RESP (``2``) or RESP3 (``3``)
          protocol for parsing responses from the server (Default ``3``).
          (See :ref:`handbook/response:redis response`)
@@ -350,9 +352,8 @@ class RedisCluster(
                 ).get()
                 kwargs["ssl_context"] = ssl_context
 
-            pool = ClusterConnectionPool(
+            pool = connection_pool_cls(
                 startup_nodes=startup_nodes,
-                blocking=blocking,
                 max_connections=max_connections,
                 reinitialize_steps=reinitialize_steps,
                 max_connections_per_node=max_connections_per_node,
@@ -367,7 +368,7 @@ class RedisCluster(
 
         super().__init__(
             connection_pool=pool,
-            connection_pool_cls=ClusterConnectionPool,
+            connection_pool_cls=connection_pool_cls,
             decode_responses=decode_responses,
             verify_version=verify_version,
             protocol_version=protocol_version,

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -632,9 +632,9 @@ class RedisCluster(
 
             if asking and redirect_addr:
                 node = self.connection_pool.nodes.nodes[redirect_addr]
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
             elif try_random_node:
-                r = self.connection_pool.get_random_connection(
+                r = await self.connection_pool.get_random_connection(
                     primary=try_random_type == NodeFlag.PRIMARIES
                 )
                 try_random_node = False
@@ -644,9 +644,9 @@ class RedisCluster(
                     node = self.connection_pool.get_primary_node_by_slot(slot)
                 else:
                     node = self.connection_pool.get_node_by_slot(slot, command)
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
             elif node:
-                r = self.connection_pool.get_connection_by_node(node)
+                r = await self.connection_pool.get_connection_by_node(node)
             else:
                 continue
 
@@ -751,7 +751,7 @@ class RedisCluster(
                 self.cache.invalidate(*keys)
         while _nodes:
             cur = _nodes[0]
-            connection = self.connection_pool.get_connection_by_node(cur)
+            connection = await self.connection_pool.get_connection_by_node(cur)
             if (
                 self.cache
                 and isinstance(self.cache, SupportsClientTracking)

--- a/coredis/pipeline.py
+++ b/coredis/pipeline.py
@@ -843,7 +843,7 @@ class ClusterPipelineImpl(Client[AnyStr], metaclass=ClusterPipelineMeta):
         if not slots:
             raise ClusterTransactionError("No slots found for transaction")
         node = self.connection_pool.get_node_by_slot(slots.pop())
-        conn = self.connection_pool.get_connection_by_node(node)
+        conn = await self.connection_pool.get_connection_by_node(node)
 
         if self.watches:
             await self._watch(node, conn, self.watches)
@@ -916,7 +916,7 @@ class ClusterPipelineImpl(Client[AnyStr], metaclass=ClusterPipelineMeta):
             if node_name not in nodes:
                 nodes[node_name] = NodeCommands(
                     self.parse_response,
-                    self.connection_pool.get_connection_by_node(node),
+                    await self.connection_pool.get_connection_by_node(node),
                 )
 
             nodes[node_name].append(c)

--- a/coredis/pool/__init__.py
+++ b/coredis/pool/__init__.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from .basic import BlockingConnectionPool, ConnectionPool
-from .cluster import ClusterConnectionPool
+from .cluster import BlockingClusterConnectionPool, ClusterConnectionPool
 
-__all__ = ["ConnectionPool", "BlockingConnectionPool", "ClusterConnectionPool"]
+__all__ = [
+    "ConnectionPool",
+    "BlockingConnectionPool",
+    "ClusterConnectionPool",
+    "BlockingClusterConnectionPool",
+]

--- a/coredis/pool/cluster.py
+++ b/coredis/pool/cluster.py
@@ -18,6 +18,7 @@ from coredis.typing import Dict, Iterable, Node, Optional, Set, StringT, Type, V
 class ClusterConnectionPool(ConnectionPool):
     """
     Custom connection pool for :class:`~coredis.RedisCluster` client
+    that can be used both in non-blocking & blocking mode.
     """
 
     nodes: NodeManager
@@ -44,6 +45,16 @@ class ClusterConnectionPool(ConnectionPool):
         **connection_kwargs: Optional[Any],
     ):
         """
+        :param max_connections: Maximum number of connections to allow concurrently from this
+         client. If the value is ``None`` it will default to 32.
+        :param max_connections_per_node: Whether to use the value of :paramref:`max_connections`
+         on a per node basis or cluster wide. If ``False`` and :paramref:`blocking` is ``True``
+         the per-node connection pools will have a maximum size of :paramref:`max_connections`
+         divided by the number of nodes in the cluster.
+        :param blocking: If ``True`` the client will block at most :paramref:`timeout` seconds
+         if :paramref:`max_connections` is reachd when trying to obtain a connection
+        :param timeout: Number of seconds to block if :paramref:`block` is ``True`` when trying to
+         obtain a connection.
         :param skip_full_coverage_check:
             Skips the check of cluster-require-full-coverage config, useful for clusters
             without the CONFIG command (like aws)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -227,6 +227,13 @@ Cluster Connection Pool
    :show-inheritance:
    :inherited-members:
 
+Blocking Cluster Connection Pool
+--------------------------------
+.. autoclass:: coredis.pool.BlockingClusterConnectionPool
+   :class-doc-from: both
+   :show-inheritance:
+   :inherited-members:
+
 Sentinel Connection Pool
 ------------------------
 

--- a/docs/source/handbook/connections.rst
+++ b/docs/source/handbook/connections.rst
@@ -1,6 +1,128 @@
 Connections
 ^^^^^^^^^^^
 
+Connection Pools
+----------------
+
+Both :class:`~coredis.Redis` and :class:`~coredis.RedisCluster` are backed by a connection
+pool that manages the underlying connections to the redis server(s). **coredis** supports
+both blocking and non-blocking connection pools. The default pool that is allocated is a
+non-blocking connection pool.
+
+To explicitly select the type of connection pool used pass in the appropriate class as
+:paramref:`coredis.Redis.connection_pool_cls` or :paramref:`coredis.RedisCluster.connection_pool_cls`.
+
+Connection pools can also be shared between multiple clients through the :paramref:`coredis.Redis.connection_pool`
+or :paramref:`coredis.RedisCluster.connection_pool` parameter.
+
+============================
+Non-Blocking Connection Pool
+============================
+
+Standalone
+    :class:`~coredis.pool.ConnectionPool`
+
+Cluster
+    :class:`~coredis.pool.ClusterConnectionPool`
+
+The default non-blocking connection pools that are allocated to clients will only allow
+upto ``max_connections`` connections to be acquired concurrently, and if more are requested
+they will raise an exception.
+
+In the following example, a client is created with ``max_connections`` set to ``2``, however ``10``
+tasks are concurrently started. This means ``8`` tasks will fail::
+
+    import coredis
+    import asyncio
+
+    async def test():
+        client = coredis.Redis(max_connections=2)
+        # or with cluster
+        # client = coredis.RedisCluster(
+        #   "localhost", 7000,
+        #   max_connections=2, max_connections_per_node=True
+        # )
+
+        await client.set("fubar", 1)
+        results = await asyncio.gather(
+            *[asyncio.get_running_loop().create_task(client.get("fubar")) for _ in range(10)],
+            return_exceptions=True
+        )
+        assert len([r for r in results if isinstance(r, Exception)]) == 8
+
+    asyncio.run(test())
+
+
+Changing ``max_connections`` to ``10`` will result in all tasks succeeding::
+
+    import coredis
+    import asyncio
+
+    async def test():
+        client = coredis.Redis(max_connections=10)
+        # or with cluster
+        # client = coredis.RedisCluster(
+        #   "localhost", 7000,
+        #   max_connections=2, max_connections_per_node=True
+        # )
+
+        await client.set("fubar", 1)
+        results = await asyncio.gather(
+            *[asyncio.get_running_loop().create_task(client.get("fubar")) for _ in range(10)],
+            return_exceptions=True
+        )
+        assert len([r for r in results if isinstance(r, Exception)]) == 0
+
+    asyncio.run(test())
+
+========================
+Blocking Connection Pool
+========================
+
+Standalone
+    :class:`~coredis.pool.BlockingConnectionPool`
+
+Cluster
+    :class:`~coredis.pool.BlockingClusterConnectionPool`
+
+Re-using the example from the :ref:`handbook/connections:non-blocking connection pool` section above,
+but using the blocking variants of the connection pools for parameters :paramref:`coredis.Redis.connection_pool_cls` or :paramref:`coredis.RedisCluster.connection_pool_cls`
+setting ``max_connections`` to ``2`` will not result in any tasks failing but instead blocking to re-use
+the ``2`` connections in the pool::
+
+
+    import coredis
+    import asyncio
+
+    async def test():
+        client = coredis.Redis(
+            connection_pool_cls=coredis.BlockingConnectionPool,
+            max_connections=2
+        )
+        # or with cluster
+        # client = coredis.RedisCluster(
+        #    "localhost", 7000,
+        #    connection_pool_cls=coredis.BlockingClusterConnectionPool,
+        #    max_connections=2,
+        #    max_connections_per_node=True
+        # )
+
+        await client.set("fubar", 1)
+        results = await asyncio.gather(
+            *[asyncio.get_running_loop().create_task(client.get("fubar")) for _ in range(10)],
+            return_exceptions=True
+        )
+        assert len([r for r in results if isinstance(r, Exception)]) == 0
+
+    asyncio.run(test())
+
+.. note:: For :class:`~coredis.pool.BlockingClusterConnectionPool` the
+   :paramref:`~coredis.pool.BlockingClusterConnectionPool.max_connections_per_node`
+   controls whether the value of :paramref:`~coredis.pool.BlockingClusterConnectionPool.max_connections`
+   is used cluster wide or per node.
+
+Connection types
+----------------
 coredis ships with three types of connections.
 
 - The default, :class:`coredis.connection.Connection`, is a normal TCP socket based connection.
@@ -23,8 +145,9 @@ coredis ships with three types of connections.
   ``READONLY`` handling is set if configured (:paramref:`coredis.RedisCluster.readonly`)
 
 
+=========================
 Custom connection classes
--------------------------
+=========================
 You can create your own connection subclasses by deriving from
 :class:`coredis.connection.BaseConnection` as well. This may be useful if
 you want to control the socket behavior within an async framework. To

--- a/docs/source/handbook/index.rst
+++ b/docs/source/handbook/index.rst
@@ -41,6 +41,7 @@ Server side scripting
 
 Performance
 -----------
+- :ref:`handbook/connections:connection pools`
 - :ref:`handbook/caching:caching`
 - :ref:`handbook/pipelines:pipelines`
 - :ref:`handbook/noreply:no reply mode`
@@ -52,6 +53,6 @@ Reliability
 
 Implementation Details
 ----------------------
-- :ref:`handbook/connections:connections`
+- :ref:`handbook/connections:connection types`
 - :ref:`handbook/development:development`
 - :ref:`handbook/typing:typing`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ Feature Summary
 
 * Application patterns
 
+  * :ref:`handbook/connections:connection pools`
   * :ref:`handbook/pubsub:pubsub`
   * :ref:`handbook/pubsub:cluster pub/sub`
   * :ref:`handbook/pubsub:sharded pub/sub`

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -107,7 +107,7 @@ class TestConnectionPool:
 
     async def test_max_connections_blocking(self, redis_cluster):
         pool = await self.get_pool(max_connections=2, blocking=True, timeout=1)
-        c1 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        _ = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         c2 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         with pytest.raises(ConnectionError):
             await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -27,6 +27,7 @@ class DummyConnection(ClusterConnection):
         self._last_error = None
         self._transport = None
         self._read_flag = asyncio.Event()
+        self._description_args = lambda: {}
 
 
 @pytest.mark.asyncio
@@ -111,7 +112,7 @@ class TestConnectionPool:
 
     async def test_max_connections_default_setting(self):
         pool = await self.get_pool(max_connections=None)
-        assert pool.max_connections == 2**31
+        assert pool.max_connections == 32
 
     async def test_pool_disconnect(self):
         pool = await self.get_pool()
@@ -126,8 +127,11 @@ class TestConnectionPool:
 
     async def test_reuse_previously_released_connection(self):
         pool = await self.get_pool()
+        print(pool._cluster_available_connections)
         c1 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        print(pool._cluster_available_connections)
         pool.release(c1)
+        print(pool._cluster_available_connections)
         c2 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         assert c1 == c2
 

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -61,11 +61,11 @@ class TestConnectionPool:
         with pytest.raises(
             RedisClusterException, match="Cant reach a single startup node"
         ):
-            pool.get_connection_by_slot(1)
+            await pool.get_connection_by_slot(1)
         with pytest.raises(
             RedisClusterException, match="Cant reach a single startup node"
         ):
-            pool.get_random_connection()
+            await pool.get_random_connection()
 
     async def test_in_use_not_exists(self, redis_cluster):
         """
@@ -79,7 +79,9 @@ class TestConnectionPool:
     async def test_connection_creation(self, redis_cluster):
         connection_kwargs = {"foo": "bar", "biz": "baz"}
         pool = await self.get_pool(connection_kwargs=connection_kwargs)
-        connection = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        connection = await pool.get_connection_by_node(
+            {"host": "127.0.0.1", "port": 7000}
+        )
         assert isinstance(connection, DummyConnection)
 
         for key in connection_kwargs:
@@ -87,25 +89,25 @@ class TestConnectionPool:
 
     async def test_multiple_connections(self, redis_cluster):
         pool = await self.get_pool()
-        c1 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        c2 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        c1 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        c2 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         assert c1 != c2
 
     async def test_max_connections(self, redis_cluster):
         pool = await self.get_pool(max_connections=2)
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         with pytest.raises(RedisClusterException):
-            pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+            await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
 
     async def test_max_connections_per_node(self, redis_cluster):
         pool = await self.get_pool(max_connections=2, max_connections_per_node=True)
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         with pytest.raises(RedisClusterException):
-            pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+            await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
 
     async def test_max_connections_default_setting(self):
         pool = await self.get_pool(max_connections=None)
@@ -113,9 +115,9 @@ class TestConnectionPool:
 
     async def test_pool_disconnect(self):
         pool = await self.get_pool()
-        c1 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        c2 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
-        c3 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        c1 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        c2 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        c3 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         pool.release(c3)
         pool.disconnect()
         assert not c1.is_connected
@@ -124,9 +126,9 @@ class TestConnectionPool:
 
     async def test_reuse_previously_released_connection(self):
         pool = await self.get_pool()
-        c1 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        c1 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         pool.release(c1)
-        c2 = pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        c2 = await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
         assert c1 == c2
 
     async def test_repr_contains_db_info_tcp(self, host_ip):
@@ -153,16 +155,16 @@ class TestConnectionPool:
             ClusterConnectionPool, "get_connection_by_slot", autospec=True
         ) as pool_mock:
 
-            def side_effect(self, *args, **kwargs):
+            async def side_effect(self, *args, **kwargs):
                 return DummyConnection(port=1337)
 
             pool_mock.side_effect = side_effect
 
-            connection = pool.get_connection_by_key("foo")
+            connection = await pool.get_connection_by_key("foo")
             assert connection.port == 1337
 
         with pytest.raises(RedisClusterException) as ex:
-            pool.get_connection_by_key(None)
+            await pool.get_connection_by_key(None)
         assert str(ex.value).startswith(
             "No way to dispatch this command to Redis Cluster."
         ), True
@@ -179,19 +181,19 @@ class TestConnectionPool:
             ClusterConnectionPool, "get_connection_by_node", autospec=True
         ) as pool_mock:
 
-            def side_effect(self, *args, **kwargs):
+            async def side_effect(self, *args, **kwargs):
                 return DummyConnection(port=1337)
 
             pool_mock.side_effect = side_effect
 
-            connection = pool.get_connection_by_slot(12182)
+            connection = await pool.get_connection_by_slot(12182)
             assert connection.port == 1337
 
-        m = Mock()
+        m = AsyncMock()
         pool.get_random_connection = m
 
         # If None value is provided then a random node should be tried/returned
-        pool.get_connection_by_slot(None)
+        await pool.get_connection_by_slot(None)
         m.assert_called_once_with()
 
     async def test_get_connection_blocked(self):
@@ -221,7 +223,7 @@ class TestConnectionPool:
             max_idle_time=0.2,
             idle_check_interval=0.1,
         )
-        conn = pool.get_connection_by_node(
+        conn = await pool.get_connection_by_node(
             {
                 "name": "127.0.0.1:7000",
                 "host": "127.0.0.1",
@@ -276,10 +278,10 @@ class TestReadOnlyConnectionPool:
 
     async def test_max_connections(self):
         pool = await self.get_pool(max_connections=2)
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
-        pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+        await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7001})
         with pytest.raises(RedisClusterException):
-            pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
+            await pool.get_connection_by_node({"host": "127.0.0.1", "port": 7000})
 
 
 class TestConnectionPoolURLParsing:

--- a/tests/commands/test_acl.py
+++ b/tests/commands/test_acl.py
@@ -20,6 +20,7 @@ async def teardown(client):
     "redis_basic_raw_resp2",
     "redis_auth",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )

--- a/tests/commands/test_bitmap.py
+++ b/tests/commands/test_bitmap.py
@@ -14,6 +14,7 @@ from tests.conftest import targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )

--- a/tests/commands/test_cluster.py
+++ b/tests/commands/test_cluster.py
@@ -12,7 +12,11 @@ from tests.conftest import targets
 
 
 @targets(
-    "redis_cluster", "redis_cluster_raw", "redis_cluster_resp2", "redis_cluster_ssl"
+    "redis_cluster",
+    "redis_cluster_blocking",
+    "redis_cluster_raw",
+    "redis_cluster_resp2",
+    "redis_cluster_ssl",
 )
 @pytest.mark.asyncio()
 class TestCluster:

--- a/tests/commands/test_functions.py
+++ b/tests/commands/test_functions.py
@@ -65,6 +65,7 @@ async def simple_library(client):
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )
@@ -129,6 +130,7 @@ class TestFunctions:
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
 )
 @pytest.mark.asyncio

--- a/tests/commands/test_generic.py
+++ b/tests/commands/test_generic.py
@@ -17,6 +17,7 @@ from tests.conftest import targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/commands/test_geo.py
+++ b/tests/commands/test_geo.py
@@ -14,6 +14,7 @@ from tests.conftest import server_deprecation_warning, targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )

--- a/tests/commands/test_hash.py
+++ b/tests/commands/test_hash.py
@@ -12,6 +12,7 @@ from tests.conftest import server_deprecation_warning, targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/commands/test_hyperloglog.py
+++ b/tests/commands/test_hyperloglog.py
@@ -12,6 +12,7 @@ from tests.conftest import targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )

--- a/tests/commands/test_list.py
+++ b/tests/commands/test_list.py
@@ -15,6 +15,7 @@ from tests.conftest import server_deprecation_warning, targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/commands/test_server.py
+++ b/tests/commands/test_server.py
@@ -19,6 +19,7 @@ from tests.conftest import targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_resp2",
 )
 @pytest.mark.asyncio()

--- a/tests/commands/test_set.py
+++ b/tests/commands/test_set.py
@@ -12,6 +12,7 @@ from tests.conftest import targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/commands/test_sorted_set.py
+++ b/tests/commands/test_sorted_set.py
@@ -16,6 +16,7 @@ from tests.conftest import server_deprecation_warning, targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/commands/test_streams.py
+++ b/tests/commands/test_streams.py
@@ -29,6 +29,7 @@ async def get_stream_message(client, stream, message_id):
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "keydb",
 )

--- a/tests/commands/test_string.py
+++ b/tests/commands/test_string.py
@@ -16,6 +16,7 @@ from tests.conftest import server_deprecation_warning, targets
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cached",
     "redis_cached_resp2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -619,6 +619,7 @@ async def redis_cluster_blocking(redis_cluster_server, request):
         startup_nodes=[{"host": "localhost", "port": 7000}],
         stream_timeout=10,
         blocking=True,
+        max_connections=32,
         decode_responses=True,
         **get_client_test_args(request),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,6 +614,32 @@ async def redis_cluster(redis_cluster_server, request):
 
 
 @pytest.fixture
+async def redis_cluster_blocking(redis_cluster_server, request):
+    pool = coredis.ClusterConnectionPool(
+        startup_nodes=[{"host": "localhost", "port": 7000}],
+        stream_timeout=10,
+        blocking=True,
+        **get_client_test_args(request),
+    )
+    cluster = coredis.RedisCluster(
+        connection_pool=pool,
+        **get_client_test_args(request),
+    )
+    await check_test_constraints(request, cluster)
+    await cluster
+    await cluster.flushall()
+    await cluster.flushdb()
+
+    for primary in cluster.primaries:
+        await set_default_test_config(primary)
+
+    async with remapped_slots(cluster, request):
+        yield cluster
+
+    cluster.connection_pool.disconnect()
+
+
+@pytest.fixture
 async def redis_cluster_ssl(redis_ssl_cluster_server, request):
     storage_url = (
         "rediss://localhost:8301/?ssl_cert_reqs=required"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -619,10 +619,12 @@ async def redis_cluster_blocking(redis_cluster_server, request):
         startup_nodes=[{"host": "localhost", "port": 7000}],
         stream_timeout=10,
         blocking=True,
+        decode_responses=True,
         **get_client_test_args(request),
     )
     cluster = coredis.RedisCluster(
         connection_pool=pool,
+        decode_responses=True,
         **get_client_test_args(request),
     )
     await check_test_constraints(request, cluster)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -48,6 +48,7 @@ class DummyCache(AbstractCache):
     "redis_basic_resp2",
     "redis_basic_raw_resp2",
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cluster_resp2",
     "redis_cluster_raw_resp2",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,6 +93,7 @@ class TestClient:
 
 @targets(
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_resp2",
 )
 @pytest.mark.asyncio

--- a/tests/test_tracking_cache.py
+++ b/tests/test_tracking_cache.py
@@ -286,6 +286,7 @@ class TestNodeInvalidatingCache(CommonExamples):
 @pytest.mark.asyncio
 @targets(
     "redis_cluster",
+    "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cluster_resp2",
     "redis_cluster_raw_resp2",

--- a/tests/test_tracking_cache.py
+++ b/tests/test_tracking_cache.py
@@ -217,10 +217,15 @@ class TestProxyInvalidatingCache(CommonExamples):
 class TestClusterProxyInvalidatingCache(CommonExamples):
     async def test_uninitialized_cache(self, client, cloner, _s):
         cache = self.cache(max_keys=1, max_size_bytes=-1)
-        assert not cache.get_client_id(client.connection_pool.get_random_connection())
+        assert not cache.get_client_id(
+            await client.connection_pool.get_random_connection()
+        )
         assert cache.confidence == 100
         _ = await cloner(client, cache=cache)
-        assert cache.get_client_id(client.connection_pool.get_random_connection()) > 0
+        assert (
+            cache.get_client_id(await client.connection_pool.get_random_connection())
+            > 0
+        )
 
     async def test_single_entry_cache_tracker_disconnected(self, client, cloner, _s):
         cache = self.cache(max_keys=1, max_size_bytes=-1)
@@ -292,10 +297,15 @@ class TestClusterInvalidatingCache(CommonExamples):
 
     async def test_uninitialized_cache(self, client, cloner, _s):
         cache = self.cache(max_keys=1, max_size_bytes=-1)
-        assert not cache.get_client_id(client.connection_pool.get_random_connection())
+        assert not cache.get_client_id(
+            await client.connection_pool.get_random_connection()
+        )
         assert cache.confidence == 100
         _ = await cloner(client, cache=cache)
-        assert cache.get_client_id(client.connection_pool.get_random_connection()) > 0
+        assert (
+            cache.get_client_id(await client.connection_pool.get_random_connection())
+            > 0
+        )
 
     async def test_single_entry_cache_tracker_disconnected(self, client, cloner, _s):
         cache = self.cache(max_keys=1, max_size_bytes=-1)


### PR DESCRIPTION
# Description

Update `ClusterConnectionPool` to support being used as a blocking connection pool.

## Side effects
- Added `connection_pool_cls` to both `Redis` & `RedisCluster` constructors
- Added `BlockingClusterConnectionPool` subclass for ease of use

## Implementation notes
The value of `max_connections` by default applies cluster wide which means it is divided by the number of nodes
to find a per node maximum queue size. This will probably behave weirdly if not explicitly specified based on the size of the cluster (especially if `readonly` is being used to read from replicas and the number of replicas is very large).
