### PR TITLE
Support python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         service_version:
           - REDIS_VERSION=6.0.16 REDIS_SENTINEL_VERSION=6.0.16 REDIS_SSL_VERSION=6.0.16 DEFAULT_ARGS=""
           - REDIS_VERSION=6.2.6 REDIS_SSL_VERSION=6.2.6 REDIS_SENTINEL_VERSION=6.2.6 REDIS_STACK_VERSION=6.2.0-edge DEFAULT_ARGS=""

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ coredis is additionally tested against:
 
 ### Supported python versions
 
+-   3.7
 -   3.8
 -   3.9
 -   3.10

--- a/coredis/_utils.py
+++ b/coredis/_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-import functools
 from functools import wraps
 from typing import Any
 
@@ -463,10 +462,19 @@ except ImportError:
 
 @enum.unique
 class CaseAndEncodingInsensitiveEnum(bytes, enum.Enum):
-    @functools.cached_property
+    __decoded: Set[StringT]
+
+    @property
     def variants(self) -> Set[StringT]:
-        decoded = str(self)
-        return {self.value.lower(), self.value, decoded.lower(), decoded.upper()}
+        if not hasattr(self, "__decoded"):
+            decoded = str(self)
+            self.__decoded = {
+                self.value.lower(),  # type: ignore
+                self.value,  # type: ignore
+                decoded.lower(),
+                decoded.upper(),
+            }
+        return self.__decoded
 
     def __eq__(self, other: object) -> bool:
         """

--- a/coredis/cache.py
+++ b/coredis/cache.py
@@ -6,7 +6,7 @@ import time
 import weakref
 from abc import ABC, abstractmethod
 from collections import Counter
-from typing import TYPE_CHECKING, Any, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 from coredis._sidecar import Sidecar
 from coredis._utils import b
@@ -26,6 +26,7 @@ from coredis.typing import (
     TypeVar,
     Union,
     ValueT,
+    runtime_checkable,
 )
 
 try:

--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -184,7 +184,8 @@ class Client(
     def noreply(self) -> bool:
         if not hasattr(self, "_noreplycontext"):
             return False
-        if ctx := self._noreplycontext.get() is not None:
+        ctx = self._noreplycontext.get()
+        if ctx is not None:
             return ctx
         return self.__noreply
 
@@ -215,7 +216,8 @@ class Client(
             )
 
     async def _ensure_wait(self, command: bytes, connection: BaseConnection) -> None:
-        if wait := self._waitcontext.get():
+        wait = self._waitcontext.get()
+        if wait:
             await connection.send_command(CommandName.WAIT, *wait)
             if not cast(int, await connection.read_response(decode=False)) >= wait[0]:
                 raise ReplicationError(command, wait[0], wait[1])

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -81,7 +81,8 @@ class ClusterMeta(ABCMeta):
 
         for name, method in methods.items():
             doc_addition = ""
-            if cmd := getattr(method, "__coredis_command", None):
+            cmd = getattr(method, "__coredis_command", None)
+            if cmd:
                 if cmd.cluster.route:
                     kls.ROUTING_FLAGS[cmd.command] = cmd.cluster.route
                     aggregate_note = ""
@@ -605,11 +606,12 @@ class RedisCluster(
             return list(self.connection_pool.nodes.all_nodes())
         elif node_flag == NodeFlag.SLOT_ID:
             slot_id: Optional[ValueT] = kwargs.get("slot_id")
-            if node_from_slot := (
+            node_from_slot = (
                 self.connection_pool.nodes.node_from_slot(int(slot_id))
                 if slot_id is not None
                 else None
-            ):
+            )
+            if node_from_slot:
                 return [node_from_slot]
         return None
 

--- a/coredis/commands/function.py
+++ b/coredis/commands/function.py
@@ -303,8 +303,10 @@ class Library(Generic[AnyStr]):
                 bound_arguments = sig.bind(*a, **k)
                 bound_arguments.apply_defaults()
                 arguments: Dict[str, Any] = bound_arguments.arguments
-                instance: Library[AnyStr]
-                if not isinstance(instance := arguments.pop(first_arg), Library):
+                instance: Library[AnyStr] = arguments.pop(first_arg)
+                if not isinstance(
+                    instance, Library
+                ):  # pyright: reportUnnecessaryIsInstance=false
                     raise RuntimeError(
                         f"{instance.__class__.__name__} is not a subclass of"
                         " coredis.commands.function.Library therefore it's methods cannot be bound "

--- a/coredis/commands/pubsub.py
+++ b/coredis/commands/pubsub.py
@@ -601,8 +601,7 @@ class ShardedPubSub(BasePubSub[AnyStr, "coredis.pool.ClusterConnectionPool"]):
                     task.cancel()
         # If there were no pending results check the shards
         if not result:
-            tasks: Dict[str, asyncio.Task[ResponseType]]
-            if tasks := {
+            tasks: Dict[str, asyncio.Task[ResponseType]] = {
                 node_id: asyncio.create_task(
                     self._execute(
                         connection,
@@ -615,7 +614,8 @@ class ShardedPubSub(BasePubSub[AnyStr, "coredis.pool.ClusterConnectionPool"]):
                 )
                 for node_id, connection in self.shard_connections.items()
                 if node_id not in self.pending_tasks
-            }:
+            }
+            if tasks:
                 done, pending = await asyncio.wait(
                     tasks.values(),
                     timeout=timeout if (timeout and timeout > 0) else None,

--- a/coredis/connection.py
+++ b/coredis/connection.py
@@ -365,12 +365,14 @@ class BaseConnection(asyncio.BaseProtocol):
         decode: Optional[bool] = None,
         push_message_types: Optional[Set[bytes]] = None,
     ) -> ResponseType:
+        response = self._parser.get_response(decode, push_message_types)
         while isinstance(
-            (response := self._parser.get_response(decode, push_message_types)),
+            response,
             NotEnoughData,
         ):
             self._read_flag.clear()
             await self._read_flag.wait()
+            response = self._parser.get_response(decode, push_message_types)
 
         return response
 

--- a/coredis/pipeline.py
+++ b/coredis/pipeline.py
@@ -225,7 +225,8 @@ class ClusterPipelineMeta(PipelineMeta):
     def __new__(cls, name: str, bases: Tuple[type, ...], namespace: Dict[str, object]):
         kls = super().__new__(cls, name, bases, namespace)
         for name, method in ClusterPipelineMeta.get_methods(kls).items():
-            if cmd := getattr(method, "__coredis_command", None):
+            cmd = getattr(method, "__coredis_command", None)
+            if cmd:
                 if cmd.cluster.route:
                     kls.NODES_FLAGS[cmd.command] = cmd.cluster.route
                 if cmd.cluster.multi_node:

--- a/coredis/pool/cluster.py
+++ b/coredis/pool/cluster.py
@@ -320,7 +320,8 @@ class ClusterConnectionPool(ConnectionPool):
         ):
             while True:
                 try:
-                    if _connection := available_connections.get_nowait():
+                    _connection = available_connections.get_nowait()
+                    if _connection:
                         _connection.disconnect()
                 except asyncio.QueueEmpty:
                     break
@@ -335,7 +336,8 @@ class ClusterConnectionPool(ConnectionPool):
     async def get_random_connection(self, primary: bool = False) -> ClusterConnection:
         """Opens new connection to random redis server in the cluster"""
         for node in self.nodes.random_startup_node_iter(primary):
-            if connection := await self.get_connection_by_node(node):
+            connection = await self.get_connection_by_node(node)
+            if connection:
                 return connection
         raise RedisClusterException("Cant reach a single startup node.")
 

--- a/coredis/pool/nodemanager.py
+++ b/coredis/pool/nodemanager.py
@@ -92,7 +92,8 @@ class NodeManager:
     ) -> Dict[str, Dict[int, List[ValueT]]]:
         mapping: Dict[str, Dict[int, List[ValueT]]] = {}
         for k in keys:
-            if node := self.node_from_slot(hash_slot(b(k))):
+            node = self.node_from_slot(hash_slot(b(k)))
+            if node:
                 mapping.setdefault(node.name, {}).setdefault(
                     hash_slot(b(k)), []
                 ).append(k)

--- a/coredis/response/_callbacks/__init__.py
+++ b/coredis/response/_callbacks/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import datetime
 import itertools
 from abc import ABC, ABCMeta, abstractmethod
-from typing import SupportsFloat, SupportsInt, cast
+from typing import cast
 
 from coredis._utils import b
 from coredis.exceptions import ClusterResponseError, ResponseError
@@ -77,7 +77,8 @@ class ResponseCallback(ABC, Generic[RESP, RESP3, R], metaclass=ResponseCallbackM
     ) -> R:
         self.version = version
         if isinstance(response, ResponseError):
-            if exc_to_response := self.handle_exception(response):
+            exc_to_response = self.handle_exception(response)
+            if exc_to_response:
                 return exc_to_response
         if version == 3:
             return self.transform_3(cast(RESP3, response), **options)
@@ -291,7 +292,7 @@ class FloatCallback(
     def transform(self, response: ResponseType, **options: Optional[ValueT]) -> float:
         if isinstance(response, float):
             return response
-        if isinstance(response, (SupportsFloat, SupportsInt, bytes, str)):
+        if isinstance(response, (int, bytes, str)):
             return float(response)
 
         raise ValueError(f"Unable to map {response} to float")

--- a/coredis/response/_callbacks/sorted_set.py
+++ b/coredis/response/_callbacks/sorted_set.py
@@ -104,7 +104,8 @@ class ZMPopCallback(
         self, response: Optional[List[ResponseType]], **options: Optional[ValueT]
     ) -> Optional[Tuple[AnyStr, ScoredMembers]]:
 
-        if r := cast(Tuple[AnyStr, List[Tuple[AnyStr, int]]], response):
+        r = cast(Tuple[AnyStr, List[Tuple[AnyStr, int]]], response)
+        if r:
             return r[0], tuple(ScoredMember(v[0], float(v[1])) for v in r[1])
 
         return None

--- a/coredis/stream.py
+++ b/coredis/stream.py
@@ -108,10 +108,12 @@ class Consumer(Generic[AnyStr]):
 
         for stream in self.streams:
             try:
-                if info := await self.client.xinfo_stream(stream):  # type: ignore[has-type]
-                    if last_entry := info["last-entry"]:
+                info = await self.client.xinfo_stream(stream)
+                if info:
+                    last_entry = info["last-entry"]
+                    if last_entry:
                         self.state[stream].setdefault(
-                            "identifier", last_entry.identifier  # type: ignore[has-type]
+                            "identifier", last_entry.identifier
                         )
             except ResponseError:
                 pass

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -14,21 +14,18 @@ from typing import (
     ClassVar,
     Coroutine,
     Dict,
-    Final,
     Generator,
     Generic,
     Hashable,
     Iterable,
     Iterator,
     List,
-    Literal,
     Mapping,
     MutableMapping,
     MutableSequence,
     MutableSet,
     NamedTuple,
     Optional,
-    Protocol,
     Sequence,
     Set,
     Tuple,
@@ -40,12 +37,16 @@ from typing import (
 
 from typing_extensions import (
     Deque,
+    Final,
+    Literal,
     OrderedDict,
     ParamSpec,
+    Protocol,
     Self,
     TypeAlias,
     TypedDict,
     TypeGuard,
+    runtime_checkable,
 )
 
 _runtime_checks = False
@@ -70,7 +71,6 @@ try:
             Sequence,
             Set,
             Tuple,
-            TypedDict,
             ValuesView,
         )
 
@@ -223,6 +223,7 @@ __all__ = [
     "Protocol",
     "ResponsePrimitive",
     "ResponseType",
+    "runtime_checkable",
     "Sequence",
     "Self",
     "Set",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,6 +158,7 @@ coredis is additionally tested against:
 Supported python versions
 -------------------------
 
+- 3.7
 - 3.8
 - 3.9
 - 3.10

--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/cluster/test_cluster_connection_pool.py
+++ b/tests/cluster/test_cluster_connection_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -270,6 +270,14 @@ class TestConnectionPool:
 
             connection = await pool.get_connection_by_slot(12182)
             assert connection.port == 1337
+
+        class AsyncMock(Mock):
+            def __await__(self):
+                future = asyncio.Future(loop=asyncio.get_event_loop())
+                future.set_result(self)
+                result = yield from future
+
+                return result
 
         m = AsyncMock()
         pool.get_random_connection = m

--- a/tests/cluster/test_node_manager.py
+++ b/tests/cluster/test_node_manager.py
@@ -15,6 +15,7 @@ from coredis.pool.nodemanager import HASH_SLOTS, ManagedNode, NodeManager
 
 
 @pytest.mark.asyncio
+@pytest.mark.min_python("3.8")
 async def test_init_slots_cache_not_all_slots(s, redis_cluster):
     """
     Test that if not all slots are covered it should raise an exception
@@ -85,6 +86,7 @@ async def test_init_slots_cache_not_all_slots(s, redis_cluster):
 
 
 @pytest.mark.asyncio
+@pytest.mark.min_python("3.8")
 async def test_init_slots_cache_not_all_slots_not_require_full_coverage(
     s, redis_cluster
 ):
@@ -144,6 +146,7 @@ async def test_init_slots_cache_not_all_slots_not_require_full_coverage(
 
 
 @pytest.mark.asyncio
+@pytest.mark.min_python("3.8")
 async def test_init_slots_cache(s, redis_cluster):
     """
     Test that slots cache can in initialized and all slots are covered
@@ -311,6 +314,7 @@ async def test_reset(redis_cluster):
 
 
 @pytest.mark.asyncio
+@pytest.mark.min_python("3.8")
 async def test_cluster_one_instance(redis_cluster):
     """
     If the cluster exists of only 1 node then there is some hacks that must

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from coredis.typing import RUNTIME_TYPECHECKS, Callable, Optional, R, ValueT
 
 REDIS_VERSIONS = {}
 PY_IMPLEMENTATION = platform.python_implementation()
+PY_VERSION = version.Version(platform.python_version())
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -56,6 +57,9 @@ async def check_test_constraints(request, client, protocol=3):
     await get_version(client)
     client_version = REDIS_VERSIONS[str(client)]
     for marker in request.node.iter_markers():
+        if marker.name == "min_python" and marker.args:
+            if PY_VERSION < version.parse(marker.args[0]):
+                return pytest.skip(f"Skipped for python versions < {marker.args[0]}")
         if marker.name == "min_server_version" and marker.args:
             if client_version < version.parse(marker.args[0]):
                 return pytest.skip(f"Skipped for versions < {marker.args[0]}")

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -245,6 +245,7 @@ async def test_master_address_by_name(client):
 
 
 @targets("redis_sentinel", "redis_sentinel_resp2")
+@pytest.mark.min_python("3.8")
 async def test_failover(client, mocker):
     mock_exec = mocker.patch.object(
         client.sentinels[0], "execute_command", autospec=True
@@ -295,6 +296,7 @@ async def test_sentinel_replicas(client):
 
 
 @targets("redis_sentinel", "redis_sentinel_resp2")
+@pytest.mark.min_python("3.8")
 async def test_no_replicas(client, mocker):
     p = await client.replica_for("mymaster")
     replica_rotate = mocker.patch.object(p.connection_pool, "rotate_replicas")


### PR DESCRIPTION
# Description
Re-enable support for python 3.7

- Remove use of walrus operator
- Remove use of functools.cached_property
- Import runtime_checkable/Protocol from typing_extensions

## Related issues
#79 