### PR TITLE
Improve locking recipe

### DIFF
--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -217,7 +217,7 @@ class Client(
 
     async def _ensure_wait(self, command: bytes, connection: BaseConnection) -> None:
         wait = self._waitcontext.get()
-        if wait:
+        if wait and wait[0] > 0:
             await connection.send_command(CommandName.WAIT, *wait)
             if not cast(int, await connection.read_response(decode=False)) >= wait[0]:
                 raise ReplicationError(command, wait[0], wait[1])

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -551,6 +551,10 @@ class RedisCluster(
                 self.connection_pool.nodes.get_redis_link(replica.host, replica.port),
             )
 
+    @property
+    def num_replicas_per_shard(self) -> int:
+        return self.connection_pool.nodes.replicas_per_shard
+
     def _determine_slot(self, command: bytes, *args: ValueT) -> Optional[int]:
         """Figures out what slot based on command and args"""
         keys = KeySpec.extract_keys(

--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -553,6 +553,10 @@ class RedisCluster(
 
     @property
     def num_replicas_per_shard(self) -> int:
+        """
+        Number of replicas per shard of the cluster determined by
+        initial cluster topology discovery
+        """
         return self.connection_pool.nodes.replicas_per_shard
 
     def _determine_slot(self, command: bytes, *args: ValueT) -> Optional[int]:

--- a/coredis/pool/nodemanager.py
+++ b/coredis/pool/nodemanager.py
@@ -269,7 +269,7 @@ class NodeManager:
         # Set the tmp variables to the real variables
         self.slots = tmp_slots
         self.nodes = nodes_cache
-        self.replicas_per_shard = (
+        self.replicas_per_shard = int(
             (len(self.nodes) / len(replicas)) - 1 if replicas else 0
         )
         self.reinitialize_counter = 0

--- a/coredis/pool/nodemanager.py
+++ b/coredis/pool/nodemanager.py
@@ -20,6 +20,7 @@ from coredis.typing import (
     Literal,
     Node,
     Optional,
+    Set,
     StringT,
     ValueT,
 )
@@ -173,7 +174,7 @@ class NodeManager:
         self.startup_nodes_reachable = False
 
         nodes = self.orig_startup_nodes
-        replicas = set()
+        replicas: Set[str] = set()
 
         # With this option the client will attempt to connect to any of the previous set of nodes
         # instead of the original set of startup nodes

--- a/coredis/recipes/locks/lua_lock.py
+++ b/coredis/recipes/locks/lua_lock.py
@@ -203,7 +203,7 @@ class LuaLock(Generic[AnyStr]):
             return math.ceil(self.client.num_replicas_per_shard / 2)
         return 0
 
-    async def __acquire(self, token: StringT, stop_trying_at: Optional[int]) -> bool:
+    async def __acquire(self, token: StringT, stop_trying_at: Optional[float]) -> bool:
         if isinstance(self.client, RedisCluster):
             try:
 

--- a/coredis/recipes/locks/lua_lock.py
+++ b/coredis/recipes/locks/lua_lock.py
@@ -207,16 +207,11 @@ class LuaLock(Generic[AnyStr]):
         if isinstance(self.client, RedisCluster):
             try:
 
-                if self.blocking:
-                    replication_wait = (
-                        1000 * (max(0, stop_trying_at - time.time()))
-                        if stop_trying_at is not None
-                        else 0
-                    )
-                else:
-                    replication_wait = 1000 * (
-                        self.timeout if self.timeout is not None else 0.1
-                    )
+                replication_wait = (
+                    1000 * (max(0, stop_trying_at - time.time()))
+                    if stop_trying_at is not None
+                    else 100
+                )
                 with self.client.ensure_replication(
                     self.replication_factor, timeout_ms=int(replication_wait)
                 ):

--- a/coredis/recipes/locks/lua_lock.py
+++ b/coredis/recipes/locks/lua_lock.py
@@ -225,8 +225,9 @@ class LuaLock(Generic[AnyStr]):
                 warnings.warn(
                     f"Unable to ensure lock {self.name!r} was replicated "
                     f"to {self.replication_factor} replicas",
-                    category=RuntimeWarning
+                    category=RuntimeWarning,
                 )
+                await self.client.delete([self.name])
                 return False
         else:
             return await self.client.set(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - REDIS_SENTINEL_PASSWORD=sekret
     ports:
       - '36379:26379'
-  # cluster
+  # cluster with replication
   redis-cluster-1:
     image: "redis:${REDIS_VERSION:-latest}"
     command: redis-server --port 7000 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
@@ -83,6 +83,7 @@ services:
     ports:
       - '7005:7005'
       - '17005:17005'
+  # ssl cluster with replication
   redis-cluster-init:
     image: "redis:${REDIS_VERSION:-latest}"
     command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 1 ${HOST_IP}:7000 ${HOST_IP}:7001 ${HOST_IP}:7002 ${HOST_IP}:7003 ${HOST_IP}:7004 ${HOST_IP}:7005"
@@ -141,6 +142,30 @@ services:
     depends_on: [redis-ssl-cluster-1, redis-ssl-cluster-2, redis-ssl-cluster-3, redis-ssl-cluster-4, redis-ssl-cluster-5, redis-ssl-cluster-6]
     volumes:
       - ./tests/tls:/tls
+  # primary only cluster
+  redis-cluster-noreplica-1:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8400 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    ports:
+      - '8400:8400'
+      - '18400:18400'
+  redis-cluster-noreplica-2:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8401 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    depends_on: [redis-cluster-1]
+    ports:
+      - '8401:8401'
+      - '18401:18401'
+  redis-cluster-noreplica-3:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8402 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP}
+    ports:
+      - '8402:8402'
+      - '18402:18402'
+  redis-cluster-noreplica-init:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 0 ${HOST_IP}:8400 ${HOST_IP}:8401 ${HOST_IP}:8402"
+    depends_on: [redis-cluster-noreplica-1, redis-cluster-noreplica-2, redis-cluster-noreplica-3]
   redis-basic:
     image: "redis:${REDIS_VERSION:-latest}"
     command: redis-server --port 6379 ${DEFAULT_ARGS---enable-debug-command yes}

--- a/docs/source/recipes/locks.rst
+++ b/docs/source/recipes/locks.rst
@@ -9,7 +9,7 @@ The implementation is based on `the distributed locking pattern described in red
 
 When used with a :class:`~coredis.RedisCluster` instance, acquiring the lock includes
 ensuring that the token set by the :meth:`~coredis.recipes.locks.LuaLock.acquire` method
-is replicated to atleast one replica using the :meth:`~coredis.RedisCluster.ensure_replication`
+is replicated to atleast ``n/2`` replicas using the :meth:`~coredis.RedisCluster.ensure_replication`
 context manager.
 
 The implementation uses the following LUA scripts:

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ addopts =
     --capture=no
     -rfEsxX
     -K
+    --timeout=5
 asyncio_mode = auto
 markers =
     auth

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,7 +6,6 @@ addopts =
     --capture=no
     -rfEsxX
     -K
-    --timeout=5
 asyncio_mode = auto
 markers =
     auth

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,8 +23,10 @@ markers =
     ssl
     uds
     nocluster
+    noreplica
     noresp3
     clusteronly
+    replicated_clusteronly
     cached
     min_python
     min_server_version

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,5 +10,4 @@ pytest-cov
 pytest-env
 pytest-lazy-fixture
 pytest-mock
-pytest-timeout
 redis

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,5 @@ pytest-cov
 pytest-env
 pytest-lazy-fixture
 pytest-mock
+pytest-timeout
 redis

--- a/tests/commands/test_cluster.py
+++ b/tests/commands/test_cluster.py
@@ -107,6 +107,7 @@ class TestCluster:
         assert len(replicas) == len(replicas_depr) == 1
 
     @pytest.mark.min_server_version("7.0.0")
+    @pytest.mark.replicated_clusteronly
     async def test_cluster_links(self, client, _s):
         links = []
         for node in client.primaries:

--- a/tests/commands/test_cluster.py
+++ b/tests/commands/test_cluster.py
@@ -13,6 +13,7 @@ from tests.conftest import targets
 
 @targets(
     "redis_cluster",
+    "redis_cluster_noreplica",
     "redis_cluster_blocking",
     "redis_cluster_raw",
     "redis_cluster_resp2",
@@ -60,6 +61,7 @@ class TestCluster:
             node.host, node.port
         ).cluster_addslots([1, 2])
 
+    @pytest.mark.replicated_clusteronly
     async def test_readonly_explicit(self, client, _s):
         await client.set("fubar", 1)
         slot = hash_slot(b"fubar")
@@ -73,6 +75,7 @@ class TestCluster:
         with pytest.raises(MovedError):
             await node_client.get("fubar")
 
+    @pytest.mark.replicated_clusteronly
     async def test_cluster_info(self, client, _s):
         info = await client.cluster_info()
         assert info["cluster_state"] == "ok"
@@ -90,6 +93,7 @@ class TestCluster:
         assert await client.cluster_countkeysinslot(slot) == 1
         assert await client.cluster_getkeysinslot(slot, 1) == (_s("a"),)
 
+    @pytest.mark.replicated_clusteronly
     async def test_cluster_nodes(self, client, _s):
         nodes = await client.cluster_nodes()
         assert len(nodes) == 6

--- a/tests/recipes/test_lua_lock.py
+++ b/tests/recipes/test_lua_lock.py
@@ -15,6 +15,7 @@ from tests.conftest import targets
     "redis_basic_raw",
     "redis_basic_resp2",
     "redis_cluster",
+    "redis_cluster_noreplica",
     "redis_cluster_raw",
     "redis_cluster_resp2",
 )

--- a/tests/recipes/test_lua_lock.py
+++ b/tests/recipes/test_lua_lock.py
@@ -73,7 +73,7 @@ class TestLock:
     async def test_lock_replication_failed(self, client, mocker):
         replication_factor = mocker.patch(
             "coredis.recipes.locks.LuaLock.replication_factor",
-            new_callable=PropertyMock
+            new_callable=PropertyMock,
         )
         replication_factor.return_value = 2
         lock1 = LuaLock(client, "foo", blocking=True, blocking_timeout=1)


### PR DESCRIPTION
# Description
As noted in #71 - the recipe fails when there are no replicas in the cluster and the requirement of having the lock replicated to `1` replica is not sufficient for production setups.

## Changes
- Skip calling `WAIT` if there are no replicas 
- Use `n/2` replicas for ensuring the lock is acquired if num_replicas > 0
- Ensure replication wait is capped to `blocking_timeout` if it was specified else, set it to 100ms
- If the lock can't be replicated within the timeout, do not raise a `LockError` but instead issue a warning and return `False`. Additionally delete the acquired yet unreplicated lock to ensure an unreplicated lock without a timeout doesn't result in future attempts failing.