### PR TITLE
Improve error discovery during cluster intiialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,29 @@ services:
     image: "redis:${REDIS_VERSION:-latest}"
     command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 0 ${HOST_IP}:8400 ${HOST_IP}:8401 ${HOST_IP}:8402"
     depends_on: [redis-cluster-noreplica-1, redis-cluster-noreplica-2, redis-cluster-noreplica-3]
+  # auth required cluster
+  redis-cluster-auth-1:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8500 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8500:8500'
+      - '18500:18500'
+  redis-cluster-auth-2:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8501 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8501:8501'
+      - '18501:18501'
+  redis-cluster-auth-3:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: redis-server --port 8502 ${DEFAULT_ARGS---enable-debug-command yes} --protected-mode no --cluster-enabled yes --loglevel verbose --cluster-announce-ip ${HOST_IP} --requirepass sekret
+    ports:
+      - '8502:8502'
+      - '18502:18502'
+  redis-cluster-auth-init:
+    image: "redis:${REDIS_VERSION:-latest}"
+    command: bash -c "echo yes | redis-cli --cluster create --cluster-replicas 0 ${HOST_IP}:8500 ${HOST_IP}:8501 ${HOST_IP}:8502 -a sekret"
+    depends_on: [redis-cluster-auth-1, redis-cluster-auth-2, redis-cluster-auth-3]
   redis-basic:
     image: "redis:${REDIS_VERSION:-latest}"
     command: redis-server --port 6379 ${DEFAULT_ARGS---enable-debug-command yes}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -151,6 +151,21 @@ Compatibility
 **coredis** is tested against redis versions ``6.0.x``, ``6.2.x`` & ``7.0.x``. The
 test matrix status can be reviewed `here <https://github.com/alisaifee/coredis/actions/workflows/main.yml>`__
 
+.. note:: Though **coredis** officially only supports :redis-version:`6.0.0` and above it is known to work with lower
+   versions.
+
+   A known compatibility issue with older redis versions is the lack of support for :term:`RESP3` and
+   the :rediscommand:`HELLO` command. The default :class:`~coredis.Redis` and :class:`~coredis.RedisCluster` clients
+   do not work in this scenario as the :rediscommand:`HELLO` command is used for initial handshaking to confirm that
+   the default ``RESP3`` protocol version can be used and to perform authentication if necessary.
+
+   This can be worked around by passing ``2`` to :paramref:`coredis.Redis.protocol_version` to downgrade to :term:`RESP`
+   (see :ref:`handbook/response:redis response`).
+
+   When using :term:`RESP` **coredis** will also fall back to the legacy :rediscommand:`AUTH` command if the
+   :rediscommand:`HELLO` is not supported.
+
+
 coredis is additionally tested against:
 
 - :pypi:`uvloop` >= `0.15.0`.

--- a/tests/cluster/test_node_manager.py
+++ b/tests/cluster/test_node_manager.py
@@ -384,3 +384,9 @@ async def test_init_with_down_node(redis_cluster):
         with pytest.raises(RedisClusterException) as e:
             await n.initialize()
         assert "Redis Cluster cannot be connected" in str(e.value)
+
+
+@pytest.mark.asyncio
+async def test_cluster_initialization_fail(redis_cluster_auth, cloner):
+    with pytest.raises(RedisClusterException, match="invalid username-password pair"):
+        await cloner(redis_cluster_auth, password="wrong")


### PR DESCRIPTION
# Description
When the startup nodes provided to the redis cluster client can't be reached the underlying errors were being swallowed and made it difficult for developers to discover & correct configuration errors.

## Related Issues
#89 