### PR TITLE
Fix cluster pubsub with uninitialized connection pool

### DIFF
--- a/coredis/commands/pubsub.py
+++ b/coredis/commands/pubsub.py
@@ -71,7 +71,9 @@ class BasePubSub(Generic[AnyStr, PoolT]):
         if hasattr(self, "encoding"):
             return
 
+        await self.connection_pool.initialize()
         conn = await self.connection_pool.get_connection(b"pubsub")
+
         try:
             self.encoding = conn.encoding
             self.decode_responses = conn.decode_responses

--- a/tests/cluster/test_pubsub.py
+++ b/tests/cluster/test_pubsub.py
@@ -309,6 +309,22 @@ class TestPubSubSubscribeUnsubscribe:
             assert message is None
         assert p.subscribed is False
 
+    @pytest.mark.asyncio
+    async def test_uninitialized_client(self, redis_cluster, cloner):
+        client = await cloner(redis_cluster, initialize=False)
+        p = client.pubsub()
+        assert not client.connection_pool.initialized
+        await p.subscribe("foo")
+        assert p.subscribed
+
+    @pytest.mark.asyncio
+    async def test_sharded_pubsub_uninitialized_client(self, redis_cluster, cloner):
+        client = await cloner(redis_cluster, initialize=False)
+        p = client.sharded_pubsub()
+        assert not client.connection_pool.initialized
+        await p.subscribe("foo")
+        assert p.subscribed
+
 
 class TestPubSubMessages:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1057,7 +1057,7 @@ def _s(client):
 
 @pytest.fixture
 def cloner():
-    async def _cloner(client, connection_kwargs={}, **kwargs):
+    async def _cloner(client, initialize=True, connection_kwargs={}, **kwargs):
         if isinstance(client, coredis.client.Redis):
             c_kwargs = client.connection_pool.connection_kwargs
             c_kwargs.update(connection_kwargs)
@@ -1077,7 +1077,8 @@ def cloner():
                 encoding=client.encoding,
                 **kwargs,
             )
-        await c.ping()
+        if initialize:
+            await c.ping()
         return c
 
     return _cloner


### PR DESCRIPTION
# Description 
If a cluster pubsub or sharded pubsub worker is created with an uninitialized connection pool, the first 'subscribe'
command fails to initialize the connection pool and thus fails to reserve a connection for the pubsub worker.

## Related issues
#88 