### PR TITLE
Connection initialization synchronization fix

### DIFF
--- a/coredis/pool/basic.py
+++ b/coredis/pool/basic.py
@@ -288,7 +288,7 @@ class ConnectionPool:
         self.checkpid()
         try:
             connection = self._available_connections.pop()
-            if connection.needs_handshake:
+            if connection.is_connected and connection.needs_handshake:
                 await connection.perform_handshake()
         except IndexError:
             if self._created_connections >= self.max_connections:
@@ -436,7 +436,7 @@ class BlockingConnectionPool(ConnectionPool):
         try:
             async with async_timeout.timeout(self.timeout):
                 connection = await self._pool.get()
-            if connection and connection.needs_handshake:
+            if connection and connection.is_connected and connection.needs_handshake:
                 await connection.perform_handshake()
         except asyncio.TimeoutError:
             raise ConnectionError("No connection available.")

--- a/coredis/pool/cluster.py
+++ b/coredis/pool/cluster.py
@@ -241,7 +241,7 @@ class ClusterConnectionPool(ConnectionPool):
         if not connection:
             connection = self._make_node_connection(node)
         else:
-            if connection.needs_handshake:
+            if connection.is_connected and connection.needs_handshake:
                 await connection.perform_handshake()
 
         if acquire:


### PR DESCRIPTION
# Description
When the connection pool is uninitialised and a large number of coroutines start up at the same time (for example on application startup) there is a chance where more than one coroutine sees the Connection as "not connected" and therefore triggering multiple initialization sequences that would result in multiple sockets established for the same Connection instance. Depending on timing this could mean multiple sockets being read from into the same buffer.