### PR TITLE
Separate lock release/extension errors

### DIFF
--- a/coredis/exceptions.py
+++ b/coredis/exceptions.py
@@ -154,6 +154,14 @@ class LockError(RedisError, ValueError):
     # This was originally chosen to behave like threading.Lock.
 
 
+class LockReleaseError(LockError):
+    """Errors releasing a lock"""
+
+
+class LockExtensionError(LockError):
+    """Errors extending a lock"""
+
+
 class RedisClusterException(Exception):
     """Base exception for the RedisCluster client"""
 
@@ -316,6 +324,7 @@ class UnknownCommandError(ResponseError):
 
     def __init__(self, message: str) -> None:
         command_match = self.ERROR_REGEX.findall(message)
+
         if command_match:
             self.command = command_match.pop()
         super().__init__(message)

--- a/coredis/exceptions.py
+++ b/coredis/exceptions.py
@@ -154,6 +154,10 @@ class LockError(RedisError, ValueError):
     # This was originally chosen to behave like threading.Lock.
 
 
+class LockAcquisitionError(LockError):
+    """Errors acquiring a lock"""
+
+
 class LockReleaseError(LockError):
     """Errors releasing a lock"""
 

--- a/docs/source/api/errors.rst
+++ b/docs/source/api/errors.rst
@@ -80,6 +80,10 @@ General Exceptions
    :no-inherited-members:
 .. autoexception:: coredis.exceptions.LockError
    :no-inherited-members:
+.. autoexception:: coredis.exceptions.LockReleaseError
+   :no-inherited-members:
+.. autoexception:: coredis.exceptions.LockExtensionError
+   :no-inherited-members:
 .. autoexception:: coredis.exceptions.NoKeyError
    :no-inherited-members:
 .. autoexception:: coredis.exceptions.PersistenceError

--- a/docs/source/api/errors.rst
+++ b/docs/source/api/errors.rst
@@ -80,6 +80,8 @@ General Exceptions
    :no-inherited-members:
 .. autoexception:: coredis.exceptions.LockError
    :no-inherited-members:
+.. autoexception:: coredis.exceptions.LockAcquisitionError
+   :no-inherited-members:
 .. autoexception:: coredis.exceptions.LockReleaseError
    :no-inherited-members:
 .. autoexception:: coredis.exceptions.LockExtensionError


### PR DESCRIPTION
# Description

Specialize the exceptions thrown in the locking recipe to easily distinguish between lock release errors and lock extension errors.
