### PR TITLE
fix: unsubscribing twice from the same pubsub channel raises a KeyError exception

### DIFF
--- a/coredis/commands/pubsub.py
+++ b/coredis/commands/pubsub.py
@@ -397,7 +397,7 @@ class BasePubSub(Generic[AnyStr, PoolT]):
                 subscribed_dict = self.patterns
             else:
                 subscribed_dict = self.channels
-            subscribed_dict.pop(message["channel"])
+            subscribed_dict.pop(message["channel"], None)
 
         if message_type in self.PUBLISH_MESSAGE_TYPES:
             handler = None


### PR DESCRIPTION
Trying to unsubscribe twice from the same pubsub channel raises a `KeyError` exception upon calling `get_message()`. 

Steps to reproduce: 
```python

import asyncio
import coredis


async def test():
    r = coredis.Redis.from_url("redis://127.0.0.1:6379")
    p = r.pubsub()

    await p.subscribe('channel')
    for _ in range(0, 10):
        await p.get_message(timeout=0.01)

    await p.unsubscribe('channel')
    await asyncio.sleep(0.1)
    await p.get_message()

    # unsub again
    await p.unsubscribe('channel')
    await asyncio.sleep(0.1)

    # the below will throw exception
    await p.get_message()


asyncio.run(test())


```

