### PR TITLE
Gracefully handle MODULE LIST error

### DIFF
--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -34,10 +34,12 @@ from coredis.connection import (
 from coredis.credentials import AbstractCredentialProvider
 from coredis.exceptions import (
     AuthenticationError,
+    AuthorizationError,
     ConnectionError,
     PersistenceError,
     RedisError,
     ReplicationError,
+    ResponseError,
     TimeoutError,
     UnknownCommandError,
     WatchError,
@@ -339,7 +341,13 @@ class Client(
                 ver, minor = divmod(ver, 100)
                 ver, major = divmod(ver, 100)
                 self._module_info[name] = version.Version(f"{major}.{minor}.{patch}")
-        except (UnknownCommandError, AuthenticationError):
+        except (UnknownCommandError, AuthenticationError, AuthorizationError):
+            self._module_info = {}
+        except ResponseError as err:
+            warnings.warn(
+                "Unable to determine module support due to response error from "
+                f"`MODULE LIST`: {err}."
+            )
             self._module_info = {}
 
     async def initialize(self: ClientT) -> ClientT:


### PR DESCRIPTION
This change enables the client code to work even when there is an ACL that prevents MODULE LIST for running successfully.

Fixes #300 