### PR TITLE
Allow multiplexing of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fast, async, fully-typed Redis client with support for cluster and sentinel
 - Fully typed, even when using pipelines, Lua scripts, and libraries
 - Redis [Cluster](https://coredis.readthedocs.org/en/latest/handbook/cluster.html#redis-cluster) and [Sentinel](https://coredis.readthedocs.org/en/latest/api/clients.html#sentinel) support
 - Built with structured concurrency on `anyio`, supports both `asyncio` and `trio`
+- Smart command routing: multiplexing when possible, [pooling](https://coredis.readthedocs.io/en/latest/handbook/connections.html#connection-pools) otherwise
 - Server-assisted [client-side caching](https://coredis.readthedocs.org/en/latest/handbook/caching.html) implementation
 - [Redis Stack modules](https://coredis.readthedocs.org/en/latest/handbook/modules.html) support
 - [Redis PubSub](https://coredis.readthedocs.org/en/latest/handbook/pubsub.html)

--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -935,70 +935,79 @@ class Redis(Client[AnyStr]):
         **options: Unpack[ExecutionParameters],
     ) -> R:
         pool = self.connection_pool
-        async with pool.acquire() as connection:
-            try:
-                keys = KeySpec.extract_keys(command.name, *command.arguments)
-                cacheable = (
-                    command.name in CACHEABLE_COMMANDS
-                    and len(keys) == 1
-                    and not self.noreply
-                    and self._decodecontext.get() is None
-                )
-                cached_reply = None
-                cache_hit = False
-                use_cached = False
-                reply = None
-                if self.cache:
-                    if connection.tracking_client_id != self.cache.get_client_id(connection):
-                        self.cache.reset()
-                        await connection.update_tracking_client(
-                            True, self.cache.get_client_id(connection)
-                        )
-                    if command.name not in READONLY_COMMANDS:
-                        self.cache.invalidate(*keys)
-                    elif cacheable:
-                        try:
-                            cached_reply = cast(
-                                R,
-                                self.cache.get(
-                                    command.name,
-                                    keys[0],
-                                    *command.arguments,
-                                ),
-                            )
-                            use_cached = random.random() * 100.0 < min(100.0, self.cache.confidence)
-                            cache_hit = True
-                        except KeyError:
-                            pass
-                if not (use_cached and cached_reply):
-                    request = await connection.create_request(
-                        command.name,
-                        *command.arguments,
-                        noreply=self.noreply,
-                        decode=options.get("decode", self._decodecontext.get()),
-                        encoding=self._encodingcontext.get(),
+        quick_release = self.should_quick_release(command)
+        should_block = not quick_release or self.requires_wait or self.requires_waitaof
+        keys = KeySpec.extract_keys(command.name, *command.arguments)
+        cacheable = (
+            command.name in CACHEABLE_COMMANDS
+            and len(keys) == 1
+            and not self.noreply
+            and self._decodecontext.get() is None
+        )
+        cached_reply = None
+        cache_hit = False
+        use_cached = False
+        reply = None
+        released = False
+        connection = await pool.get_connection()
+        self._ensure_server_version(connection.server_version)
+        try:
+            if self.cache:
+                if connection.tracking_client_id != self.cache.get_client_id(connection):
+                    self.cache.reset()
+                    await connection.update_tracking_client(
+                        True, self.cache.get_client_id(connection)
                     )
-                    reply = await request
-                    await self._ensure_wait_and_persist(command, connection)
-                    if self.noreply:
-                        return None  # type: ignore
-                    if isinstance(callback, AsyncPreProcessingCallback):
-                        await callback.pre_process(self, reply)
-                if self.cache and cacheable:
-                    if cache_hit and not use_cached:
-                        self.cache.feedback(
-                            command.name, keys[0], *command.arguments, match=cached_reply == reply
+                if command.name not in READONLY_COMMANDS:
+                    self.cache.invalidate(*keys)
+                elif cacheable:
+                    try:
+                        cached_reply = cast(
+                            R,
+                            self.cache.get(
+                                command.name,
+                                keys[0],
+                                *command.arguments,
+                            ),
                         )
-                    if not cache_hit:
-                        self.cache.put(
-                            command.name,
-                            keys[0],
-                            *command.arguments,
-                            value=reply,
-                        )
-                return callback(cached_reply if cache_hit else reply)
-            finally:
-                self._ensure_server_version(connection.server_version)
+                        use_cached = random.random() * 100.0 < min(100.0, self.cache.confidence)
+                        cache_hit = True
+                    except KeyError:
+                        pass
+            if not (use_cached and cached_reply):
+                request = await connection.create_request(
+                    command.name,
+                    *command.arguments,
+                    noreply=self.noreply,
+                    decode=options.get("decode", self._decodecontext.get()),
+                    encoding=self._encodingcontext.get(),
+                )
+                # if not blocking, no need to wait for reply
+                if not should_block:
+                    released = True
+                    pool.release(connection)
+                reply = await request
+                await self._ensure_wait_and_persist(command, connection)
+                if self.noreply:
+                    return None  # type: ignore
+                if isinstance(callback, AsyncPreProcessingCallback):
+                    await callback.pre_process(self, reply)
+            if self.cache and cacheable:
+                if cache_hit and not use_cached:
+                    self.cache.feedback(
+                        command.name, keys[0], *command.arguments, match=cached_reply == reply
+                    )
+                if not cache_hit:
+                    self.cache.put(
+                        command.name,
+                        keys[0],
+                        *command.arguments,
+                        value=reply,
+                    )
+            return callback(cached_reply if cache_hit else reply)
+        finally:
+            if not released:
+                pool.release(connection)
 
     @overload
     def decoding(

--- a/coredis/connection.py
+++ b/coredis/connection.py
@@ -28,6 +28,7 @@ from typing_extensions import override
 import coredis
 from coredis._packer import Packer
 from coredis._utils import logger, nativestr
+from coredis.commands.constants import CommandName
 from coredis.credentials import (
     AbstractCredentialProvider,
     UserPass,
@@ -288,7 +289,7 @@ class BaseConnection:
             while self._requests:
                 request = self._requests.popleft()
                 request.fail(disconnect_exc)
-            self._connection = None
+            self._connected, self._connection = False, None
 
     async def listen_for_responses(self) -> None:
         """
@@ -479,7 +480,6 @@ class BaseConnection:
         """
         Send a command to the redis server
         """
-        from coredis.commands.constants import CommandName
 
         cmd_list = []
         if self.is_connected and noreply and not self.noreply:

--- a/coredis/pipeline.py
+++ b/coredis/pipeline.py
@@ -515,9 +515,7 @@ class Pipeline(Client[AnyStr], metaclass=PipelineMeta):
             request = await self.connection.create_request(
                 command.name, *command.arguments, decode=kwargs.get("decode")
             )
-            return callback(
-                await request,
-            )
+            return callback(await request)
         except (ConnectionError, TimeoutError):
             # if we're not already watching, we can safely retry the command
             try:


### PR DESCRIPTION
This is a second attempt to implement multiplexing after the original proved too complex. This one is quite a bit simpler: usage of the `acquire()` context manager determines whether a connection is multiplexing or not. If you exit the context manager before waiting for command results, it's essentially multiplexing; otherwise, it's dedicated. (Basically, you keep the connection as long as you need it and things work as expected.)

The new behavior is:
- Cache and pubsub: dedicated only (with reconnection and keepalive logic), equivalent to current behavior
- Client: dedicated for blocking/wait/wait AOF, multiplexing for everything else
- Pipeline: dedicated by default, since WATCH requires a dedicated connection. However, users can now pass `allow_watch=False` to the pipeline constructor and a multiplexing connection will be used instead for better performance. We could also make this default to True, though that would require users to update some of their pipeline code.

The nice thing about this is we get a lot of the performance benefits of valkey GLIDE, but without making users think about when they need to use a separate client to get a dedicated connection.

Still missing from implementation, though they'll work as before using dedicated connections:
- [ ] Cluster client
- [ ] Cluster pipeline
- [ ] Cluster pubsub