### PR TITLE
note no name param in breaking changes; simplify README

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -32,8 +32,10 @@ Release Date: 2026-01-18
     * Removed ``__len__`` and ``__bool__`` methods of :class:`coredis.pipeline.Pipeline`
     * Drop support for explicit management of ``watch``, ``unwatch``, ``multi`` in pipelines. This
       is replaced by the :meth:`coredis.pipeline.Pipeline.watch` async context manager.
-  * When defining type stubs for FFI for Lua scripts or library functions, keys can only be distinguished
-    from arguments by annotating them with :class:`coredis.typing.KeyT`.
+  * When defining type stubs for FFI for Lua scripts or library functions, keys can only be
+    distinguished from arguments by annotating them with :class:`coredis.typing.KeyT`. When
+    wrapping a type stub with the ``wraps`` decorator, the ``name`` parameter is no longer
+    present; instead, the stub name must match the Lua function's name.
 
 * Removals
 


### PR DESCRIPTION
Previously `wraps` had a `name` parameter which is now gone, so added that to list of breaking changes.

Simplifies README a bit: example is now runnable by default and easier to see how it could be run on asyncio or Trio. It also includes a pipeline and comments about types, since these are some of the most interesting features of coredis. Supported Python versions is removed since that's already in a badge on the top of the README, and the "Redis API Compatible Databases" section is collapsed into the "tested against" section since that communicates the same thing. Sentinel code is removed from the README because that's unlikely to be what people are looking for when just getting started with coredis and sentinel support is already noted elsewhere.

The broad idea is for the README to showcase some of the cool/helpful features and point users to the docs for anything more in-depth.
