### PR TITLE
Refactor Script & Library classes for consistency

### DIFF
--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -147,7 +147,6 @@ from coredis.response.types import (
 from coredis.tokens import PrefixToken, PureToken
 from coredis.typing import (
     AnyStr,
-    Callable,
     CommandArgList,
     JsonType,
     KeyT,
@@ -158,7 +157,6 @@ from coredis.typing import (
     ResponsePrimitive,
     ResponseType,
     StringT,
-    T_co,
     ValueT,
 )
 
@@ -6169,15 +6167,14 @@ class CoreCommands(CommandMixin[AnyStr]):
         sha1: StringT,
         keys: Parameters[KeyT] | None = None,
         args: Parameters[ValueT] | None = None,
-        callback: Callable[..., T_co] = NoopCallback(),
-    ) -> CommandRequest[T_co]:
+    ) -> CommandRequest[ResponseType]:
         _keys: list[KeyT] = list(keys) if keys else []
         command_arguments: CommandArgList = [sha1, len(_keys), *_keys]
 
         if args:
             command_arguments.extend(args)
 
-        return self.create_request(command, *command_arguments, callback=callback)
+        return self.create_request(command, *command_arguments, callback=NoopCallback())
 
     @redis_command(CommandName.EVALSHA, group=CommandGroup.SCRIPTING)
     def evalsha(
@@ -6185,8 +6182,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         sha1: StringT,
         keys: Parameters[KeyT] | None = None,
         args: Parameters[ValueT] | None = None,
-        callback: Callable[..., T_co] = NoopCallback(),
-    ) -> CommandRequest[T_co]:
+    ) -> CommandRequest[ResponseType]:
         """
         Execute the Lua script cached by it's :paramref:`sha` ref with the
         key names and argument values in :paramref:`keys` and :paramref:`args`.
@@ -6195,7 +6191,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         :return: The result of the script as redis returns it
         """
 
-        return self._evalsha(CommandName.EVALSHA, sha1, keys, args, callback=callback)
+        return self._evalsha(CommandName.EVALSHA, sha1, keys, args)
 
     @versionadded(version="3.0.0")
     @redis_command(
@@ -6209,8 +6205,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         sha1: StringT,
         keys: Parameters[KeyT] | None = None,
         args: Parameters[ValueT] | None = None,
-        callback: Callable[..., T_co] = NoopCallback(),
-    ) -> CommandRequest[T_co]:
+    ) -> CommandRequest[ResponseType]:
         """
         Read-only variant of :meth:`~Redis.evalsha` that cannot execute commands
         that modify data.
@@ -6218,7 +6213,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         :return: The result of the script as redis returns it
         """
 
-        return self._evalsha(CommandName.EVALSHA_RO, sha1, keys, args, callback=callback)
+        return self._evalsha(CommandName.EVALSHA_RO, sha1, keys, args)
 
     @versionadded(version="3.0.0")
     @redis_command(
@@ -6326,8 +6321,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         function: StringT,
         keys: Parameters[KeyT] | None = None,
         args: Parameters[ValueT] | None = None,
-        callback: Callable[..., T_co] = NoopCallback(),
-    ) -> CommandRequest[T_co]:
+    ) -> CommandRequest[ResponseType]:
         """
         Invoke a function
         """
@@ -6339,7 +6333,7 @@ class CoreCommands(CommandMixin[AnyStr]):
             *(args or []),
         ]
 
-        return self.create_request(CommandName.FCALL, *command_arguments, callback=callback)
+        return self.create_request(CommandName.FCALL, *command_arguments, callback=NoopCallback())
 
     @versionadded(version="3.1.0")
     @redis_command(
@@ -6353,8 +6347,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         function: StringT,
         keys: Parameters[KeyT] | None = None,
         args: Parameters[ValueT] | None = None,
-        callback: Callable[..., T_co] = NoopCallback(),
-    ) -> CommandRequest[T_co]:
+    ) -> CommandRequest[ResponseType]:
         """
         Read-only variant of :meth:`~coredis.Redis.fcall`
         """
@@ -6366,7 +6359,9 @@ class CoreCommands(CommandMixin[AnyStr]):
             *(args or []),
         ]
 
-        return self.create_request(CommandName.FCALL_RO, *command_arguments, callback=callback)
+        return self.create_request(
+            CommandName.FCALL_RO, *command_arguments, callback=NoopCallback()
+        )
 
     @versionadded(version="3.1.0")
     @redis_command(

--- a/docs/source/handbook/scripting.rst
+++ b/docs/source/handbook/scripting.rst
@@ -35,6 +35,8 @@ invoked by calling it like a function. Script instances accept the following opt
   script. If client isn't specified, the client that initially
   created the :class:`coredis.commands.Script` instance (the one that :meth:`~coredis.Redis.register_script` was
   invoked from) will be used.
+* **callback**: A custom callback to call on the raw response from redis beforee
+  returning it.
 
 Continuing the example from above:
 
@@ -43,6 +45,8 @@ Continuing the example from above:
     await r.set('foo', 2)
     await multiply(keys=['foo'], args=[5])
     # 10
+    await multiple(keys=['foo'], args=[5], callback=lambda value: float(value))
+    # 10.0
 
 The value of key 'foo' is set to 2. When multiply is invoked, the 'foo' key is
 passed to the script along with the multiplier value of 5. LUA executes the
@@ -230,3 +234,12 @@ This can now be used as you would expect::
 
         await lib.hmmget("k1", "k2", a=1, b=2, c=3, d=4, e=5, f=6)
         # [b"10", b"20", b"30", b"40", b"5", b"6"]
+
+
+
+
+Libraries can also be used with pipelines::
+
+    async with coredis.Redis() as client:
+        async with client.pipeline() as pipeline:
+            lib = await MyLib(pipeline)

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -186,6 +186,17 @@ class TestScripting:
         await client.delete(["key"])
         await default_get("key", "coredis") == "coredis"
 
+    async def test_wraps_function_with_callback(self, client):
+        script = client.register_script("return redis.call('GET', KEYS[1]) or ARGV[1]")
+
+        @script.wraps(callback=lambda value: int(value))
+        async def int_get(key: KeyT, default: RedisValueT) -> int: ...
+
+        await client.set("key", 1)
+        await int_get("key", 2) == 1
+        await client.delete(["key"])
+        await int_get("key", 2) == 2
+
     async def test_wraps_function_key_value_type_checking(self, client):
         script = client.register_script("return redis.call('GET', KEYS[1]) or ARGV[1]")
 


### PR DESCRIPTION
# TL;DR 

Refactor the changes in 6.x to `Script`, `Library` and related scripting functions to be internally consistent by not exposing `callbacks` in core commands so as to maintain a direct mapping with the redis command documentation. 

# Details
- Removes the callback arguments from the core commands `evalsha`, `evalsha_ro`, `fcall` & `fcall_ro` to stay consistent with only exposing arguments that map to the redis docs.
- The callback arguments exposed by `Script.__call__`, `Function.__call__` and the associated `wraps` decorators still exist, but internally use the `transform` callback chain to be consistent with how core command responses are transformed. The `transform` method previously did not accept arbitrary callbacks, but it does now.
- The api of the wraps decorators now only accepts keyword arguments as no arguments are actually required
- The `function_name` parameter for the wraps decorator for library functions is reintroduced as an optional argument. There didn't appear to be any reason to remove it and it allows for the same lua function to be declared with different callbacks and signatures.
- The special handling for pipelines in the library `wraps` decorator has been removed since it didn't appear to be necessary as this was already handled by the `initialize` method of the `Library` class