### PR TITLE
Fix unsafe CapacityLimiter initialization at import time

### DIFF
--- a/coredis/connection/_base.py
+++ b/coredis/connection/_base.py
@@ -192,7 +192,7 @@ class BaseConnection(ABC):
         noevict: bool = False,
         notouch: bool = False,
         ssl_context: ssl.SSLContext | None = None,
-        processing_budget: CapacityLimiter = CapacityLimiter(1),
+        processing_budget: CapacityLimiter | None = None,
     ):
         """
         :param stream_timeout: Maximum time to wait for receiving a response
@@ -280,7 +280,7 @@ class BaseConnection(ABC):
         self._terminated = False
 
         # To be used in the read task for cpu bound processing after data is received
-        self._processing_budget = processing_budget
+        self._processing_budget = processing_budget or CapacityLimiter(1)
 
     def __repr__(self) -> str:
         return self.describe()


### PR DESCRIPTION
I was running into some nasty bugs when using cluster pubsub. They only showed up when running asyncio cluster tests followed by Trio cluster tests, pointing to shared state somewhere. Turns out ``CapacityLimiter`` is initialized at import time since it's a default argument value! (This is hands down the most annoying Python default behavior, I've been bitten by this before...)

Instead of defaulting to a single, module-wide object, it's now optional and we create the limiter in ``__init__`` if it wasn't passed.

I believe this showed up in cluster specifically because ``ClusterConnectionPool`` doesn't pass a limiter, unlike ``ConnectionPool``.
