### PR TITLE
Fix typing errors caused by invariant list type

### DIFF
--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -552,6 +552,7 @@ RedisValueT: TypeAlias = str | bytes | int | float
 #:     length(b"123")              # invalid
 
 
+@runtime_checkable
 class SequenceNotString(Protocol[T_co]):
     """
     Allow sequences *except* str | bytes.

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -549,7 +549,7 @@ RedisValueT: TypeAlias = str | bytes | int | float
 #:     length({"1": 2})            # invalid
 #:     length("123")               # invalid
 #:     length(b"123")              # invalid
-Parameters = list[T_co] | Set[T_co] | tuple[T_co, ...] | ValuesView[T_co] | Iterator[T_co]
+Parameters = Sequence[T_co] | Set[T_co] | tuple[T_co, ...] | ValuesView[T_co] | Iterator[T_co]
 
 if sys.version_info >= (3, 12):
     from ._py_312_typing import JsonType, ResponsePrimitive, ResponseType

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -42,6 +42,7 @@ from typing import (
     cast,
     get_origin,
     get_type_hints,
+    overload,
     runtime_checkable,
 )
 
@@ -549,7 +550,34 @@ RedisValueT: TypeAlias = str | bytes | int | float
 #:     length({"1": 2})            # invalid
 #:     length("123")               # invalid
 #:     length(b"123")              # invalid
-Parameters = Sequence[T_co] | Set[T_co] | tuple[T_co, ...] | ValuesView[T_co] | Iterator[T_co]
+
+
+class SequenceNotString(Protocol[T_co]):
+    """
+    Allow sequences *except* str | bytes.
+
+    Use this to disallow passing a single str | bytes instance where a sequence of
+    strings is expected.
+    """
+
+    def __contains__(self, value: object, /) -> bool: ...
+
+    @overload
+    def __getitem__(self, index: int, /) -> T_co: ...
+
+    @overload
+    def __getitem__(self, index: slice, /) -> Sequence[T_co]: ...
+
+    def __len__(self) -> int: ...
+
+    def __iter__(self) -> Iterator[T_co]: ...
+
+    def __reversed__(self, /) -> Iterator[T_co]: ...
+
+
+Parameters = (
+    SequenceNotString[T_co] | Set[T_co] | tuple[T_co, ...] | ValuesView[T_co] | Iterator[T_co]
+)
 
 if sys.version_info >= (3, 12):
     from ._py_312_typing import JsonType, ResponsePrimitive, ResponseType


### PR DESCRIPTION
A lot of commands use the `Parameters` type, which is a union of a couple types, one of which is `list[T_co]`.

Since `list` is an invariant type, this means a `list[str]` can't be passed to a `Parameters[KeyT]`. This is quite annoying in lots of very common cases:

```python
async with Redis(decode_responses=True) as client:
    keys = ["a", "b"]
    await client.mget(keys)
```

Here, the MGET call actually needs to be marked with `# type: ignore` when using pyright or mypy!

Luckily the fix is very simple. The `Sequence` type *is* covariant so we can simply change parameters to use `Sequence[T_co]`.
