### PR TITLE
Handle initialization races and unsafe concurrent sharing

### DIFF
--- a/coredis/pool/_base.py
+++ b/coredis/pool/_base.py
@@ -129,11 +129,11 @@ class BaseConnectionPool(ABC, Generic[ConnectionT]):
     async def __aexit__(self, *args: Any) -> None:
         self._counter -= 1
         if self._counter == 0:
-            self._reset()
             self._task_group.cancel_scope.cancel()
-            await self._task_group.__aexit__(*args)
+            self._reset()
             if self._anchor_reset_token:
                 self._anchor_active.reset(self._anchor_reset_token)
+            await self._task_group.__aexit__(*args)
 
     @abstractmethod
     async def _initialize(self) -> None:

--- a/coredis/pool/_base.py
+++ b/coredis/pool/_base.py
@@ -119,9 +119,9 @@ class BaseConnectionPool(ABC, Generic[ConnectionT]):
                     raise RuntimeError(
                         "Implicit concurrent connection pool sharing detected. "
                         "You must explicitly enter the pool in a parent task "
-                        "(`async with pool:`) before spawning concurrent tasks that "
-                        "share it to ensure that cleanup occurs in the same "
-                        "task where it was initialized."
+                        "before spawning concurrent tasks that "
+                        "share it. (For more details see "
+                        "https://coredis.readthedocs.io/en/stable/handbook/connections.html#sharing-a-connection-pool)"
                     )
                 self._counter += 1
             return self


### PR DESCRIPTION
# Problems

* A herd of concurrent tasks could try to use the pool before `_initialize()` has completed.
* Since AnyIO strictly requires that a cancel scope (in this case the task group of the connection pool) be exited by the exact same task that created it, there was a very easily reproducable scenario where an uninitialized pool shared by concurrent tasks would be initialized (counter=1) by a short lived task which would exit before the other tasks sharing the pool do. This would result in the last task (the task that decrements counter to 0) to try and cancel the task group and fail.

# Solution
- Add a `Lock` in the context enter 
- Use a context var to store the "anchor" that tracks task ancestry. If concurrent workers attempt to share an unanchored pool, the pool fails early raising a less cryptic exception than the one which would eventually be raised by anyio.


# Manual reproduction

```python
from typing import Any
import anyio
import coredis


async def task(pool: coredis.ConnectionPool[Any]) -> None:
    async with coredis.Redis(connection_pool=pool) as client:
        await client.ping()


async def main() -> None:
    pool = coredis.ConnectionPool.from_url("redis://localhost:6379")
    async with anyio.create_task_group() as tg:
        tg.start_soon(task, pool)
        tg.start_soon(task, pool)
        tg.start_soon(task, pool)
    # raises RuntimeError: Attempted to exit cancel scope in a different task than it was entered in

anyio.run(main)
```