### PR TITLE
fix: clean up task group when __aenter__ fails during _initialize()

### DIFF
--- a/coredis/pool/_base.py
+++ b/coredis/pool/_base.py
@@ -141,7 +141,11 @@ class BaseConnectionPool(ABC, Generic[ConnectionT]):
                 self._anchor_reset_token = self._anchor_active.set(True)
                 self._counter += 1
                 await self._task_group.__aenter__()
-                await self._initialize()
+                try:
+                    await self._initialize()
+                except BaseException:
+                    await self.__aexit__(None, None, None)
+                    raise
             else:
                 if not self._anchor_active.get():
                     raise RuntimeError(

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -182,7 +182,7 @@ class TestConnectionPoolFailedInitialization:
             async with pool:
                 pass
 
-        assert pool._counter == 0
+        assert pool._task_group.cancel_scope.cancel_called
 
         if sniffio.current_async_library() == "trio":
             import trio

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import anyio
 import pytest
+import sniffio
 
 import coredis.connection
 from coredis import ClusterConnectionPool, ConnectionPool, TCPConnection, UnixDomainSocketConnection
@@ -161,6 +162,32 @@ class TestBasicPoolParameters:
         client.connection_pool.timeout = 1
         with pytest.RaisesGroup(TimeoutError):
             await gather(*(client.blpop(["test"], timeout=2) for _ in range(3)))
+
+
+class TestConnectionPoolFailedInitialization:
+    async def test_failed_cluster_pool_aenter_cleans_up_task_group(self):
+        """When ClusterConnectionPool.__aenter__ fails to connect, the internally
+        managed task group must be cleaned up. Otherwise, under Trio the orphaned
+        nursery corrupts the task's nursery stack, making it impossible to continue
+        after catching the error.
+        """
+        pool = ClusterConnectionPool(
+            startup_nodes=[TCPLocation("localhost", 1)],
+            skip_full_coverage_check=True,
+            connect_timeout=0.5,
+            stream_timeout=0.5,
+        )
+
+        with pytest.raises(BaseException):
+            async with pool:
+                pass
+
+        assert pool._counter == 0
+
+        if sniffio.current_async_library() == "trio":
+            import trio
+
+            assert len(trio.lowlevel.current_task()._child_nurseries) == 0
 
 
 class TestBasicConnectionPoolConstruction:


### PR DESCRIPTION
## Description

When `BaseConnectionPool.__aenter__` fails during `_initialize()` (e.g. unreachable cluster nodes), the manually-managed task group's `__aexit__` is never called. Python's context manager protocol does not call
`__aexit__` if `__aenter__` raises. Since `self._task_group.__aenter__()` is called explicitly (not via `async with`), there is no `finally` block to ensure `self._task_group.__aexit__()` runs.

This leaves the task group's nursery on Trio's `task._child_nurseries`stack. When the task later exits, Trio detects the orphaned nursery and raises `RuntimeError("Nursery stack corrupted")`. Under asyncio the
cleanup is less strict and the bug is silent, but the pool's `_counter` is still leaked (stuck at 1), preventing any subsequent re-entry.

## Motivation

Applications that use Redis as an optional dependency need fail-open semantics — try to connect, and if Redis is unavailable, continue without it:

```python
async def lifespan():
    try:
        async with RedisCluster.from_url("redis://host:6379") as client:
            await client.ping()
            yield client
    except* (RedisError, ConnectionError, TimeoutError, OSError):
        log.warning("Redis unavailable, continuing without cache")
        yield None
```

This pattern is impossible under Trio because the nursery corruption happens during the raise — before any `except`/`except*` handler runs. Catching the exception and continuing leaves Trio in a permanently corrupt state.

## Environment

- coredis 6.1.0
- anyio 4.12.1
- trio (latest)
- Python 3.13+