### PR TITLE
Allow explicitly specifying node per command

### DIFF
--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -14,6 +14,7 @@ from anyio import sleep
 from deprecated.sphinx import versionadded, versionchanged
 
 from coredis._concurrency import gather
+from coredis._utils import b, hash_slot
 from coredis.client.basic import Client, Redis
 from coredis.cluster._node import ClusterNodeLocation
 from coredis.commands._key_spec import KeySpec
@@ -723,6 +724,19 @@ class RedisCluster(
         """
         Sends a command to one or many nodes in the cluster
         """
+        # explicit routes take preference
+        if command.by is not None:
+            if isinstance(command.by, str | bytes):
+                slot = hash_slot(b(command.by))
+                node = self.connection_pool.cluster_layout.node_for_slot(slot)
+            else:
+                node = self.connection_pool.cluster_layout.node_for_slot(command.by)
+            return await self._execute_command_on_single_node(
+                node,
+                command,
+                callback=callback,
+                **kwargs,
+            )
         prefer_replica = (
             command.name in READONLY_COMMANDS and self.connection_pool.read_from_replicas
         )

--- a/coredis/commands/request.py
+++ b/coredis/commands/request.py
@@ -66,6 +66,7 @@ class CommandRequest(Awaitable[CommandResponseT]):
             self.type_adapter.serialize(k) if isinstance(k, Serializable) else k for k in arguments
         )
         self.kwargs = kwargs
+        self.by: bytes | str | int | None = None
 
     def run(self) -> Awaitable[CommandResponseT]:
         if not hasattr(self, "_response"):
@@ -162,6 +163,15 @@ class CommandRequest(Awaitable[CommandResponseT]):
             return self.client.type_adapter
 
         return empty_adapter
+
+    def route(self, by: bytes | str | int) -> CommandRequest[CommandResponseT]:
+        """
+        Explicitly set the node the command should be routed to in cluster mode.
+
+        :param by: either a key to hash by or a slot
+        """
+        self.by = by
+        return self
 
     def __await__(self) -> Generator[Any, Any, CommandResponseT]:
         return self.run().__await__()

--- a/coredis/patterns/pipeline.py
+++ b/coredis/patterns/pipeline.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from anyio import AsyncContextManagerMixin
 from deprecated.sphinx import versionchanged
 
-from coredis._utils import nativestr
+from coredis._utils import b, hash_slot, nativestr
 from coredis.client import Client, RedisCluster
 from coredis.cluster._node import ClusterNodeLocation
 from coredis.commands import CommandRequest, CommandResponseT
@@ -750,6 +750,15 @@ class ClusterPipeline(Client[AnyStr]):
         finally:
             await self._clear()
 
+    def _get_slot_for_command(self, command: ClusterPipelineCommandRequest[Any]) -> int:
+        if command.by is not None:
+            if isinstance(command.by, str | bytes):
+                return hash_slot(b(command.by))
+            return command.by
+        return self._determine_slot(
+            command.name, *command.arguments, **command.execution_parameters
+        )
+
     @retryable(policy=ConstantRetryPolicy((ClusterDownError,), retries=3, delay=0.1))
     async def _send_cluster_transaction(self, raise_on_error: bool = True) -> None:
         """
@@ -758,7 +767,7 @@ class ClusterPipeline(Client[AnyStr]):
         attempt = sorted(self.command_stack, key=lambda x: x.position)
         slots: set[int] = set()
         for c in attempt:
-            slots.add(self._determine_slot(c.name, *c.arguments, **c.execution_parameters))
+            slots.add(self._get_slot_for_command(c))
             if len(slots) > 1:
                 raise ClusterTransactionError("Multiple slots involved in transaction")
         if not slots:
@@ -812,7 +821,8 @@ class ClusterPipeline(Client[AnyStr]):
         # Group commands by node for efficient network usage.
         nodes: dict[str, NodeCommands] = {}
         for c in sorted(self.command_stack, key=lambda x: x.position):
-            node = self.connection_pool.cluster_layout.node_for_request(c.name, c.arguments)
+            slot = self._get_slot_for_command(c)
+            node = self.connection_pool.cluster_layout.node_for_slot(slot)
 
             if node.name not in nodes:
                 nodes[node.name] = NodeCommands(

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -116,6 +116,7 @@ class RedisCommandP(Protocol):
     name: bytes
     #: All arguments to be passed to the command
     arguments: tuple[RedisValueT, ...]
+    by: bytes | str | int | None
 
 
 @dataclasses.dataclass
@@ -128,6 +129,7 @@ class RedisCommand:
     name: bytes
     #: All arguments to be passed to the command
     arguments: tuple[RedisValueT, ...]
+    by: bytes | str | int | None = None
 
 
 class ExecutionParameters(TypedDict):

--- a/tests/cluster/test_pipeline.py
+++ b/tests/cluster/test_pipeline.py
@@ -313,3 +313,17 @@ class TestPipeline:
         async with client.pipeline(timeout=5) as pipeline:
             for _ in range(20):
                 pipeline.hgetall("hash")
+
+    async def test_explicit_routing_pipeline(self, client):
+        async with client.pipeline(transaction=False) as pipe:
+            pipe.get("{1}")
+            pipe.publish("channel", "message").route("{1}")
+            pipe.keys("{1}*").route("{1}")
+        assert pipe.results == (None, 0, set())
+
+    async def test_explicit_routing_transaction(self, client):
+        async with client.pipeline(transaction=True) as pipe:
+            pipe.get("{1}")
+            pipe.publish("channel", "message").route("{1}")
+            pipe.keys("{1}*").route("{1}")
+        assert pipe.results == (None, 0, set())

--- a/tests/cluster/test_pipeline.py
+++ b/tests/cluster/test_pipeline.py
@@ -254,7 +254,7 @@ class TestPipeline:
         with pytest.raises(RedisClusterError) as exc:
             async with client.pipeline() as pipe:
                 function(pipe, *args, **kwargs)
-        exc.match("Could not map .* to a node in the cluster")
+        exc.match("No way to dispatch .* to Redis Cluster")
 
     @pytest.mark.parametrize(
         "function, args, kwargs",

--- a/tests/commands/test_cluster.py
+++ b/tests/commands/test_cluster.py
@@ -141,6 +141,17 @@ class TestCluster:
         assert _s("slots") in shards[0]
         assert _s("nodes") in shards[0]
 
+    async def test_cluster_explicit_routing(self, client, _s):
+        # spread keys across nodes
+        for i in range(16):
+            await client.set(f"prefix:{i}", 1)
+        # initial scan should succeed
+        keys = await client.keys("prefix:*")
+        assert len(keys) == 16
+        # limited scan should have less keys
+        keys = await client.keys("prefix:*").route("{1}")
+        assert len(keys) < 16
+
 
 async def test_cluster_bumpepoch(fake_redis):
     fake_redis.responses[b"CLUSTER BUMPEPOCH"] = {


### PR DESCRIPTION
Some commands don't explicitly map to a specific node (PUBLISH, SCAN, KEYS, etc). However, these commands are still useful in cluster mode and in pipelines and transactions, provided the user can control which node they land on.

This commit adds a simple property, `by`, to the `CommandRequest` class, allowing any command to specify which node it wants to land on either via a key (which can contain a hash tag), or by a specific slot.

Example code that works with this PR:

```python
async with RedisCluster("localhost", 7000, decode_responses=True) as client:
    await client.ping()
    print(await client.publish("channel", "message").route("{1}"))
    for i in range(16):
        await client.set(f"prefix:{{{i}}}", 1)
    print(await client.keys("prefix:*"))
    print(await client.keys("prefix:*").route("{1}"))

    async with client.pipeline(transaction=True) as pipe:
        pipe.get("prefix:{1}")
        pipe.publish("channel", "message").route("{1}")
        pipe.keys("prefix:*").route("{1}")
    print(pipe.results)

    async with client.pipeline(transaction=False) as pipe:
        pipe.get("prefix:{1}")
        pipe.publish("channel", "message").route("{1}")
        pipe.keys("prefix:*").route("{1}")
    print(pipe.results)
```

Fixes #348, replaces #349 (as this doesn't attempt to rehabilitate SCAN for cluster--that will be addressed in a separate PR).
