### PR TITLE
Allow SCAN in cluster when explicitly routed

### DIFF
--- a/coredis/client/cluster.py
+++ b/coredis/client/cluster.py
@@ -14,6 +14,7 @@ from anyio import sleep
 from deprecated.sphinx import versionadded, versionchanged
 
 from coredis._concurrency import gather
+from coredis._utils import b, hash_slot
 from coredis.client.basic import Client, Redis
 from coredis.cluster._node import ClusterNodeLocation
 from coredis.commands._key_spec import KeySpec
@@ -723,6 +724,19 @@ class RedisCluster(
         """
         Sends a command to one or many nodes in the cluster
         """
+        # explicit routes take preference
+        if command.by is not None:
+            if isinstance(command.by, str | bytes):
+                slot = hash_slot(b(command.by))
+                node = self.connection_pool.cluster_layout.node_for_slot(slot)
+            else:
+                node = self.connection_pool.cluster_layout.node_for_slot(command.by)
+            return await self._execute_command_on_single_node(
+                node,
+                command,
+                callback=callback,
+                **kwargs,
+            )
         prefer_replica = (
             command.name in READONLY_COMMANDS and self.connection_pool.read_from_replicas
         )

--- a/coredis/commands/_routing.py
+++ b/coredis/commands/_routing.py
@@ -341,4 +341,4 @@ class UndefinedStrategy(RoutingStrategy[R]):
 
     @property
     def description(self) -> str:
-        return """explicitly passed slot via `route()`"""
+        return """the explicitly passed slot when called with :meth:`~coredis.commands.CommandRequest.route`"""

--- a/coredis/commands/_routing.py
+++ b/coredis/commands/_routing.py
@@ -321,3 +321,24 @@ class PairStrategy(RoutingStrategy[R]):
     @property
     def description(self) -> str:
         return """the nodes serving the keys in the command"""
+
+
+class UndefinedStrategy(RoutingStrategy[R]):
+    cross_slot: ClassVar[bool] = False
+
+    def __init__(self) -> None:
+        super().__init__(NodeFlag.SLOT_ID, merge_callback=ClusterNoMerge())
+
+    def distribute(
+        self,
+        cluster_layout: ClusterLayout,
+        command: bytes,
+        arguments: tuple[RedisValueT, ...],
+        readonly: bool,
+        execution_parameters: ExecutionParameters,
+    ) -> list[NodeExecution[R]]:
+        raise NotImplementedError(f"{command.decode()} must be routed to a slot explicitly!")
+
+    @property
+    def description(self) -> str:
+        return """explicitly passed slot via `route()`"""

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -15,6 +15,7 @@ from coredis.commands._routing import (
     PairStrategy,
     RandomStrategy,
     SlotRangeStrategy,
+    UndefinedStrategy,
 )
 from coredis.commands._utils import (
     normalized_milliseconds,
@@ -3707,7 +3708,7 @@ class CoreCommands(CommandMixin[AnyStr]):
     @redis_command(
         CommandName.SCAN,
         group=CommandGroup.GENERIC,
-        cluster=ClusterCommandConfig(enabled=False),
+        cluster=ClusterCommandConfig(routing_strategy=UndefinedStrategy()),
         flags={CommandFlag.READONLY},
     )
     def scan(

--- a/coredis/commands/request.py
+++ b/coredis/commands/request.py
@@ -66,6 +66,7 @@ class CommandRequest(Awaitable[CommandResponseT]):
             self.type_adapter.serialize(k) if isinstance(k, Serializable) else k for k in arguments
         )
         self.kwargs = kwargs
+        self.by: bytes | str | int | None = None
 
     def run(self) -> Awaitable[CommandResponseT]:
         if not hasattr(self, "_response"):
@@ -162,6 +163,15 @@ class CommandRequest(Awaitable[CommandResponseT]):
             return self.client.type_adapter
 
         return empty_adapter
+
+    def route(self, by: bytes | str | int) -> CommandRequest[CommandResponseT]:
+        """
+        Explicitly set the node the command should be routed to in cluster mode.
+
+        :param by: either a key to hash by or a slot
+        """
+        self.by = by
+        return self
 
     def __await__(self) -> Generator[Any, Any, CommandResponseT]:
         return self.run().__await__()

--- a/coredis/patterns/pipeline.py
+++ b/coredis/patterns/pipeline.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 from anyio import AsyncContextManagerMixin
 from deprecated.sphinx import versionchanged
 
-from coredis._utils import nativestr
+from coredis._utils import b, hash_slot, nativestr
 from coredis.client import Client, RedisCluster
 from coredis.cluster._node import ClusterNodeLocation
 from coredis.commands import CommandRequest, CommandResponseT
@@ -750,6 +750,15 @@ class ClusterPipeline(Client[AnyStr]):
         finally:
             await self._clear()
 
+    def _get_slot_for_command(self, command: ClusterPipelineCommandRequest[Any]) -> int:
+        if command.by is not None:
+            if isinstance(command.by, str | bytes):
+                return hash_slot(b(command.by))
+            return command.by
+        return self._determine_slot(
+            command.name, *command.arguments, **command.execution_parameters
+        )
+
     @retryable(policy=ConstantRetryPolicy((ClusterDownError,), retries=3, delay=0.1))
     async def _send_cluster_transaction(self, raise_on_error: bool = True) -> None:
         """
@@ -758,7 +767,7 @@ class ClusterPipeline(Client[AnyStr]):
         attempt = sorted(self.command_stack, key=lambda x: x.position)
         slots: set[int] = set()
         for c in attempt:
-            slots.add(self._determine_slot(c.name, *c.arguments, **c.execution_parameters))
+            slots.add(self._get_slot_for_command(c))
             if len(slots) > 1:
                 raise ClusterTransactionError("Multiple slots involved in transaction")
         if not slots:
@@ -812,7 +821,8 @@ class ClusterPipeline(Client[AnyStr]):
         # Group commands by node for efficient network usage.
         nodes: dict[str, NodeCommands] = {}
         for c in sorted(self.command_stack, key=lambda x: x.position):
-            node = self.connection_pool.cluster_layout.node_for_request(c.name, c.arguments)
+            slot = self._get_slot_for_command(c)
+            node = self.connection_pool.cluster_layout.node_for_slot(slot)
 
             if node.name not in nodes:
                 nodes[node.name] = NodeCommands(

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -116,6 +116,7 @@ class RedisCommandP(Protocol):
     name: bytes
     #: All arguments to be passed to the command
     arguments: tuple[RedisValueT, ...]
+    by: bytes | str | int | None
 
 
 @dataclasses.dataclass
@@ -128,6 +129,7 @@ class RedisCommand:
     name: bytes
     #: All arguments to be passed to the command
     arguments: tuple[RedisValueT, ...]
+    by: bytes | str | int | None = None
 
 
 class ExecutionParameters(TypedDict):

--- a/tests/cluster/test_pipeline.py
+++ b/tests/cluster/test_pipeline.py
@@ -313,3 +313,17 @@ class TestPipeline:
         async with client.pipeline(timeout=5) as pipeline:
             for _ in range(20):
                 pipeline.hgetall("hash")
+
+    async def test_explicit_routing_pipeline(self, client):
+        async with client.pipeline(transaction=False) as pipe:
+            pipe.get("{1}")
+            pipe.publish("channel", "message").route("{1}")
+            pipe.keys("{1}*").route("{1}")
+        assert pipe.results == (None, 0, set())
+
+    async def test_explicit_routing_transaction(self, client):
+        async with client.pipeline(transaction=True) as pipe:
+            pipe.get("{1}")
+            pipe.publish("channel", "message").route("{1}")
+            pipe.keys("{1}*").route("{1}")
+        assert pipe.results == (None, 0, set())

--- a/tests/cluster/test_pipeline.py
+++ b/tests/cluster/test_pipeline.py
@@ -254,7 +254,7 @@ class TestPipeline:
         with pytest.raises(RedisClusterError) as exc:
             async with client.pipeline() as pipe:
                 function(pipe, *args, **kwargs)
-        exc.match("Could not map .* to a node in the cluster")
+        exc.match("No way to dispatch .* to Redis Cluster")
 
     @pytest.mark.parametrize(
         "function, args, kwargs",

--- a/tests/commands/test_cluster.py
+++ b/tests/commands/test_cluster.py
@@ -141,6 +141,17 @@ class TestCluster:
         assert _s("slots") in shards[0]
         assert _s("nodes") in shards[0]
 
+    async def test_cluster_explicit_routing(self, client, _s):
+        # spread keys across nodes
+        for i in range(16):
+            await client.set(f"prefix:{i}", 1)
+        # initial scan should succeed
+        keys = await client.keys("prefix:*")
+        assert len(keys) == 16
+        # limited scan should have less keys
+        keys = await client.keys("prefix:*").route("{1}")
+        assert len(keys) < 16
+
 
 async def test_cluster_bumpepoch(fake_redis):
     fake_redis.responses[b"CLUSTER BUMPEPOCH"] = {

--- a/tests/commands/test_generic.py
+++ b/tests/commands/test_generic.py
@@ -596,8 +596,10 @@ class TestGeneric:
     @pytest.mark.clusteronly
     async def test_scan_cluster(self, client, _s):
         await client.set("a", "1")
-        with pytest.raises(NotImplementedError, match="scan is disabled for cluster client"):
+        with pytest.raises(NotImplementedError, match="must be routed to a slot explicitly"):
             await client.scan()
+        _, keys = await client.scan(match="*").route("a")
+        assert _s("a") in keys
 
     async def test_scan_iter(self, client, _s):
         await client.set("a", "1")


### PR DESCRIPTION
Depends on: https://github.com/alisaifee/coredis/pull/352

Related: https://github.com/alisaifee/coredis/issues/348, https://github.com/alisaifee/coredis/pull/349

Allow use of the SCAN command in cluster mode, provided the command is explicitly routed to a slot via the `route()` functionality from https://github.com/alisaifee/coredis/pull/352.

This is done via adding an `UndefinedStrategy` for routing that simply raises an error when `distribute()` is called, forcing users to explicitly supply a slot. This is much simpler than an alternative approach of providing different SCAN implementations for cluster vs basic clients. It's also more flexible, as users can decide for themselves how a multi-node SCAN should work--sequential and parallel scans should work as expected and cursors can be handled however.
