### PR TITLE
fix: handle auth errors for CLIENT SETINFO gracefully

### DIFF
--- a/coredis/connection/_base.py
+++ b/coredis/connection/_base.py
@@ -31,7 +31,7 @@ from coredis._utils import logger, nativestr
 from coredis.commands.constants import CommandName
 from coredis.constants.resp import DataType
 from coredis.credentials import AbstractCredentialProvider, UserPassCredentialProvider
-from coredis.exceptions import ConnectionError, UnknownCommandError
+from coredis.exceptions import ConnectionError, ResponseError, UnknownCommandError
 from coredis.parser import NotEnoughData, Parser
 from coredis.tokens import PureToken
 from coredis.typing import (
@@ -592,16 +592,22 @@ class BaseConnection(ABC):
             self.server_version = nativestr(resp3[b"version"])
             self.client_id = int(resp3[b"id"])
             if self.server_version >= "7.2":
-                await self.create_request(
-                    b"CLIENT SETINFO",
-                    b"LIB-NAME",
-                    b"coredis",
-                )
-                await self.create_request(
-                    b"CLIENT SETINFO",
-                    b"LIB-VER",
-                    coredis.__version__,
-                )
+                try:
+                    await self.create_request(
+                        b"CLIENT SETINFO",
+                        b"LIB-NAME",
+                        b"coredis",
+                    )
+                except ResponseError:
+                    pass
+                try:
+                    await self.create_request(
+                        b"CLIENT SETINFO",
+                        b"LIB-VER",
+                        coredis.__version__,
+                    )
+                except ResponseError:
+                    pass
 
             if self._db:
                 if await self.create_request(b"SELECT", self._db, decode=False) != b"OK":

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -171,3 +171,40 @@ async def test_connection_rerun(redis_basic):
     async with create_task_group() as tg:
         with pytest.raises(RuntimeError, match="cannot be reused"):
             await tg.start(conn.run)
+
+
+# Test for CLIENT SETINFO auth error handling
+async def test_client_setinfo_auth_error_handling(redis_basic):
+    """
+    Test that CLIENT SETINFO errors are gracefully handled when
+    user lacks CLIENT permission (e.g., sentinel user).
+    This matches redis-py behavior.
+    """
+    from unittest.mock import AsyncMock, patch
+    from coredis.exceptions import ResponseError
+
+    conn = TCPConnection(location=redis_basic.connection_pool.location)
+    
+    call_count = 0
+    original_create_request = conn.create_request
+
+    async def mock_create_request(*args, **kwargs):
+        nonlocal call_count
+        # First two calls are for CLIENT SETINFO (LIB-NAME, LIB-VER)
+        if args and args[0] == b"CLIENT SETINFO":
+            call_count += 1
+            if call_count <= 2:
+                raise ResponseError("NOPERM this user has no permissions to run the 'CLIENT' command")
+        return await original_create_request(*args, **kwargs)
+
+    with patch.object(conn, 'create_request', side_effect=mock_create_request):
+        async with create_task_group() as tg:
+            await tg.start(conn.run)
+            # If the fix works, connection should still be usable
+            request = conn.create_request(b"PING")
+            result = await request
+            assert result == b"PONG"
+            tg.cancel_scope.cancel()
+    
+    # Verify CLIENT SETINFO was called and errors were caught
+    assert call_count == 2


### PR DESCRIPTION
## Description

When using Redis Sentinel with a user that lacks the `CLIENT` permission, the `CLIENT SETINFO` command fails with an auth error.

This fix wraps the `CLIENT SETINFO` commands in try/except to silently ignore such errors, matching the behavior in redis-py.

## Problem

In coredis/connection/_base.py, the `CLIENT SETINFO` commands are sent without error handling:

```python
if self.server_version >= "7.2":
    await self.create_request(b"CLIENT SETINFO", b"LIB-NAME", b"coredis")
    await self.create_request(b"CLIENT SETINFO", b"LIB-VER", coredis.__version__)
```

When the user lacks the required permission, this raises an auth error and breaks the connection.

## Solution

Wrap each `CLIENT SETINFO` call in try/except to gracefully handle auth errors:

```python
if self.server_version >= "7.2":
    try:
        await self.create_request(b"CLIENT SETINFO", b"LIB-NAME", b"coredis")
    except ResponseError:
        pass
    try:
        await self.create_request(b"CLIENT SETINFO", b"LIB-VER", coredis.__version__)
    except ResponseError:
        pass
```

This matches the behavior in redis-py which wraps these calls in try/except.

## Affected

This affects all connections, including Sentinel-managed connections where the user may have limited permissions.