### PR TITLE
Fix lock not released when using context manager on exception

### DIFF
--- a/coredis/patterns/lock/__init__.py
+++ b/coredis/patterns/lock/__init__.py
@@ -122,11 +122,12 @@ class Lock(Generic[AnyStr], AsyncContextManagerMixin):
 
     @contextlib.asynccontextmanager
     async def __asynccontextmanager__(self) -> AsyncGenerator[Self]:
-        if await self.acquire():
-            yield self
-            await self.release()
-        else:
+        if not await self.acquire():
             raise LockAcquisitionError("Could not acquire lock")
+        try:
+            yield self
+        finally:
+            await self.release()
 
     async def acquire(
         self,

--- a/tests/test_lua_lock.py
+++ b/tests/test_lua_lock.py
@@ -166,3 +166,11 @@ class TestLock:
         await client.set(lock_name, "a")
         with pytest.raises(LockError):
             await lock.extend(10)
+
+    async def test_lock_release_on_exception(self, client, lock_name):
+        lock = Lock(client, lock_name, blocking=True)
+        await client.flushdb()
+        with pytest.raises(RuntimeError):
+            async with lock:
+                raise RuntimeError("oh no!")
+        assert not await client.get(lock_name)


### PR DESCRIPTION
When using the lock's async context manager, code like:

```python
async with lock(...):
    raise ValueError
```

fails to release the lock. Opening because I'm pretty sure this is undesired behavior--imo releasing on exception is a better default. FWIW, redis-py also releases on error. For now the workaround is:

```python
lock = Lock(...)
await lock.acquire()
try:
    ...
finally:
    await lock.release()
```
