### PR TITLE
Fix cache+property decorators causing memory leak

### DIFF
--- a/coredis/_telemetry/_otel.py
+++ b/coredis/_telemetry/_otel.py
@@ -186,31 +186,26 @@ class OpenTelemetryProvider(TelemetryProvider):
 
         return attributes
 
-    @property
-    @functools.cache
+    @functools.cached_property
     def _operation_duration(self) -> Histogram:
         return self.meter.create_histogram(
             DB_CLIENT_OPERATION_DURATION,
             unit="s",
         )
 
-    @property
-    @functools.cache
+    @functools.cached_property
     def _connection_create_time(self) -> Histogram:
         return self.meter.create_histogram(DB_CLIENT_CONNECTION_CREATE_TIME, unit="s")
 
-    @property
-    @functools.cache
+    @functools.cached_property
     def _connection_use_time(self) -> Histogram:
         return self.meter.create_histogram(DB_CLIENT_CONNECTION_USE_TIME, unit="s")
 
-    @property
-    @functools.cache
+    @functools.cached_property
     def _connection_wait_time(self) -> Histogram:
         return self.meter.create_histogram(DB_CLIENT_CONNECTION_WAIT_TIME, unit="s")
 
-    @property
-    @functools.cache
+    @functools.cached_property
     def _connection_timeouts(self) -> Counter:
         return self.meter.create_counter(DB_CLIENT_CONNECTION_TIMEOUTS)
 

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -21,7 +21,7 @@ from collections.abc import (
     Set,
     ValuesView,
 )
-from functools import cache
+from functools import cached_property
 from types import GenericAlias, ModuleType, UnionType
 from typing import (
     TYPE_CHECKING,
@@ -134,8 +134,7 @@ class Key:
     def __init__(self, key: KeyT):
         self.key = key
 
-    @property
-    @cache
+    @cached_property
     def slot(self) -> int:
         from coredis._utils import b, hash_slot
 

--- a/coredis/typing.py
+++ b/coredis/typing.py
@@ -129,8 +129,6 @@ class Key:
     from other arguments
     """
 
-    __slots__ = ("key",)
-
     def __init__(self, key: KeyT):
         self.key = key
 


### PR DESCRIPTION
Fixes #375, similar to #361. Methods decorated with both `@property` and `@functools.cache` have the nasty property of keying the cache by `self`, resulting in unbounded memory growth for every instance created.

The fix is to simply use `@functools.cached_property` which behaves in a more intuitive way: values are calculated once per instance and not keyed by `self`.

I pre-emptively fixed the same issue in a few places in the otel implementation as well for correctness, though it's unlikely to be as big of an issue there.
