### PR TITLE
Add new Redis 8.8 commands

### DIFF
--- a/coredis/commands/constants.py
+++ b/coredis/commands/constants.py
@@ -580,6 +580,7 @@ class CommandName(bytes, enum.Enum):
     TS_REVRANGE = b"TS.REVRANGE"  # Since timeseries: 1.4.0
     TS_MREVRANGE = b"TS.MREVRANGE"  # Since timeseries: 1.4.0
     TS_DEL = b"TS.DEL"  # Since timeseries: 1.6.0
+    TS_BGET = b"TS.BGET"  # Since timeseries: 8.10.0
 
     #: Commands for search
     FT_CREATE = b"FT.CREATE"  # Since search: 1.0.0
@@ -604,6 +605,7 @@ class CommandName(bytes, enum.Enum):
     FT_DROPINDEX = b"FT.DROPINDEX"  # Since search: 2.0.0
     FT__LIST = b"FT._LIST"  # Since search: 2.0.0
     FT_PROFILE = b"FT.PROFILE"  # Since search: 2.2.0
+    FT_ALIASLIST = b"FT.ALIASLIST"  # Since search: 8.10.0
     FT_HYBRID = b"FT.HYBRID"  # Since search: 8.4.4
     FT_CONFIG_SET = b"FT.CONFIG SET"  # Deprecated in search: 8.0.0
     FT_CONFIG_GET = b"FT.CONFIG GET"  # Deprecated in search: 8.0.0

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -9763,7 +9763,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         flags={CommandFlag.READONLY, CommandFlag.SLOW},
         version_introduced="8.8.0",
     )
-    def argetrange(self, key: KeyT, start: int, end: int) -> CommandRequest[list[AnyStr]]:
+    def argetrange(self, key: KeyT, start: int, end: int) -> CommandRequest[list[AnyStr | None]]:
         """
         Gets values in a range of indices.
 
@@ -9776,7 +9776,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         """
 
         return self.create_request(
-            CommandName.ARGETRANGE, Key(key), start, end, callback=ListCallback[AnyStr]()
+            CommandName.ARGETRANGE, Key(key), start, end, callback=ListCallback[AnyStr | None]()
         )
 
     @overload
@@ -10100,7 +10100,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         ]
         | None = None,
         match: StringT | None = None,
-    ) -> CommandRequest[int | AnyStr | None]:
+    ) -> CommandRequest[float | None]:
         """
         Performs aggregate operations on array elements in a range.
 
@@ -10119,8 +10119,6 @@ class CoreCommands(CommandMixin[AnyStr]):
          OR — Returns the bitwise OR of all values, treating each as an integer.
          XOR — Returns the bitwise XOR of all values, treating each as an integer.
          USED — Returns the count of non-empty elements in the range.
-         SUM, MIN, and MAX return nil when no numeric elements are present in the range.
-         AND, OR, and XOR return nil when the range is empty.
         :param match: Returns the count of elements whose value equals value.
 
         :return: Result of the operation. Null if no elements match the operation.
@@ -10131,7 +10129,9 @@ class CoreCommands(CommandMixin[AnyStr]):
         if op is not None:
             command_arguments.append(op)
 
-        return self.create_request(CommandName.AROP, *command_arguments, callback=NoopCallback())
+        return self.create_request(
+            CommandName.AROP, *command_arguments, callback=OptionalFloatCallback()
+        )
 
     @versionadded(version="6.8.0")
     @redis_command(

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -59,6 +59,7 @@ from coredis.response._callbacks import (
     IntCallback,
     ItemOrTupleCallback,
     ListCallback,
+    ListOfTuplesCallback,
     NoopCallback,
     OptionalAnyStrCallback,
     OptionalFloatCallback,
@@ -130,6 +131,8 @@ from coredis.response._callbacks.vector_sets import (
     VSimCallback,
 )
 from coredis.response.types import (
+    ArrayInfo,
+    ArrayInfoFull,
     ClientInfo,
     ClusterNode,
     ClusterNodeDetail,
@@ -170,6 +173,57 @@ from coredis.typing import (
 #  from builtin types. ``set`` is a redis commands with
 #  an associated method that clashes with the set[] type.
 _Set = set
+
+
+class Predicate:
+    """
+    Field definition to be used in :meth:`~coredis.Redis.argrep`.
+
+    EXACT string — Matches elements whose value is exactly equal to string.
+    MATCH string — Matches elements whose value contains string as a substring.
+    GLOB pattern — Matches elements whose value matches the glob-style pattern (with *,
+     ?, and [...] wildcards), the same syntax used by KEYS and SCAN MATCH.
+    RE pattern — Matches elements whose value matches the regular expression pattern.
+
+    Usage::
+
+        Predicate(glob="a*") | Predicate(match="b") & Predicate(exact="cob")
+    """
+
+    @mutually_exclusive_parameters("exact", "match", "glob", "re", required=True)
+    def __init__(
+        self,
+        *,
+        exact: StringT | None = None,
+        match: StringT | None = None,
+        glob: StringT | None = None,
+        re: StringT | None = None,
+    ) -> None:
+        self._tokens: CommandArgList = []
+        if exact:
+            self._tokens.extend([PureToken.EXACT, exact])
+        elif match:
+            self._tokens.extend([PureToken.MATCH, match])
+        elif glob:
+            self._tokens.extend([PureToken.GLOB, glob])
+        elif re:  # always reachable, but help type checker out
+            self._tokens.extend([PureToken.RE, re])
+
+    @classmethod
+    def _combine(cls, left: Predicate, op: PureToken, right: Predicate) -> Predicate:
+        combined = cls.__new__(cls)
+        combined._tokens = [*left._tokens, op, *right._tokens]
+        return combined
+
+    def __or__(self, other: Predicate) -> Predicate:
+        return self._combine(self, PureToken.OR, other)
+
+    def __and__(self, other: Predicate) -> Predicate:
+        return self._combine(self, PureToken.AND, other)
+
+    @property
+    def args(self) -> CommandArgList:
+        return self._tokens
 
 
 class CoreCommands(CommandMixin[AnyStr]):
@@ -388,8 +442,14 @@ class CoreCommands(CommandMixin[AnyStr]):
             CommandName.INCRBYFLOAT, Key(key), increment, callback=FloatCallback()
         )
 
+    @versionadded(version="6.8.0")
     @mutually_exclusive_parameters("ex", "px", "exat", "pxat", "persist")
-    @redis_command(CommandName.INCREX, group=CommandGroup.STRING, flags={CommandFlag.FAST})
+    @redis_command(
+        CommandName.INCREX,
+        group=CommandGroup.STRING,
+        flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
     def increx(
         self,
         key: KeyT,
@@ -5888,9 +5948,9 @@ class CoreCommands(CommandMixin[AnyStr]):
     @versionadded(version="6.8.0")
     @redis_command(
         CommandName.XNACK,
-        version_introduced="8.8.0",
         group=CommandGroup.STREAM,
         flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
     )
     def xnack(
         self,
@@ -9404,8 +9464,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         Return information about a vector set
 
         :param key: The key containing the vector set
-        :return: mapping of attributes and values describing the vector set
 
+        :return: mapping of attributes and values describing the vector set
         """
         return self.create_request(CommandName.VINFO, Key(key), callback=VInfoCallback[AnyStr]())
 
@@ -9563,8 +9623,9 @@ class CoreCommands(CommandMixin[AnyStr]):
         CommandName.ARDEL,
         group=CommandGroup.ARRAY,
         flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
     )
-    def ardel(self, key: KeyT, indices: Parameters[ValueT]) -> CommandRequest[int]:
+    def ardel(self, key: KeyT, indices: Parameters[int]) -> CommandRequest[int]:
         """
         Deletes elements at the specified indices in an array.
 
@@ -9579,7 +9640,12 @@ class CoreCommands(CommandMixin[AnyStr]):
         return self.create_request(CommandName.ARDEL, Key(key), *indices, callback=IntCallback())
 
     @versionadded(version="6.8.0")
-    @redis_command(CommandName.ARDELRANGE, group=CommandGroup.ARRAY, flags={CommandFlag.SLOW})
+    @redis_command(
+        CommandName.ARDELRANGE,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
     def ardelrange(
         self, key: KeyT, ranges: Parameters[tuple[ValueT, ValueT]]
     ) -> CommandRequest[int]:
@@ -9610,6 +9676,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         group=CommandGroup.ARRAY,
         cacheable=True,
         flags={CommandFlag.FAST, CommandFlag.READONLY},
+        version_introduced="8.8.0",
     )
     def arget(self, key: KeyT, index: int) -> CommandRequest[AnyStr | None]:
         """
@@ -9617,6 +9684,7 @@ class CoreCommands(CommandMixin[AnyStr]):
 
         :param key: The name of the key that holds the array.
         :param index: The zero-based integer index of the element to retrieve.
+
         :return: The value at the given index, or ``None`` if the index does not exist.
         """
 
@@ -9630,6 +9698,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         group=CommandGroup.ARRAY,
         cacheable=True,
         flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
     )
     def argetrange(self, key: KeyT, start: int, end: int) -> CommandRequest[list[AnyStr]]:
         """
@@ -9645,4 +9714,393 @@ class CoreCommands(CommandMixin[AnyStr]):
 
         return self.create_request(
             CommandName.ARGETRANGE, Key(key), start, end, callback=ListCallback[AnyStr]()
+        )
+
+    @overload
+    def argrep(
+        self,
+        key: KeyT,
+        start: ValueT,
+        end: ValueT,
+        predicate: Predicate,
+        *,
+        limit: int | None = ...,
+        nocase: bool = ...,
+    ) -> CommandRequest[list[int]]: ...
+
+    @overload
+    def argrep(
+        self,
+        key: KeyT,
+        start: ValueT,
+        end: ValueT,
+        predicate: Predicate,
+        *,
+        limit: int | None = ...,
+        withvalues: Literal[True],
+        nocase: bool = ...,
+    ) -> CommandRequest[list[tuple[int, StringT]]]: ...
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARGREP,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def argrep(
+        self,
+        key: KeyT,
+        start: ValueT,
+        end: ValueT,
+        predicate: Predicate,
+        *,
+        limit: int | None = None,
+        withvalues: bool = False,
+        nocase: bool = False,
+    ) -> CommandRequest[list[int] | list[tuple[int, AnyStr]]]:
+        """
+        Searches array elements in a range using textual predicates and returns the
+        indices of the matching elements. Empty slots in the range are skipped.
+
+        :param key: The name of the key that holds the array.
+        :param start: The zero-based integer index at which to begin searching. The
+         special value - denotes the first index of the array. If start is greater than
+         end, matches are returned in reverse index order.
+        :param end: The zero-based integer index at which to stop searching (inclusive).
+         The special value + denotes the last index of the array.
+        :param predicate: One or more textual predicates to evaluate against each
+         non-empty element in the range.
+        :param limit: Stop after limit matches have been collected. limit must be a
+         positive integer. When omitted, all matches in the range are returned.
+        :param withvalues: In addition to each matching index, return the matching
+         value. The reply becomes a flat list of alternating index-value pairs.
+        :param nocase: Perform case-insensitive comparisons for EXACT, MATCH, GLOB, and RE.
+
+        :return: Indices of the matching elements, in the same order in which the range
+         is traversed (ascending when start <= end, descending when start > end). When
+         WITHVALUES is given, a flat array of alternating index-value pairs: [idx1,
+         val1, idx2, val2, ...]. An empty array is returned when the key does not exist
+         or no element matches.
+        """
+        command_arguments: CommandArgList = [Key(key), start, end]
+        command_arguments.extend(predicate.args)
+        if limit is not None:
+            command_arguments.extend([PureToken.LIMIT, limit])
+        if withvalues:
+            command_arguments.append(PureToken.WITHVALUES)
+        if nocase:
+            command_arguments.append(PureToken.NOCASE)
+
+        if withvalues:
+            return self.create_request(
+                CommandName.ARGREP, *command_arguments, callback=ListOfTuplesCallback[int, AnyStr]()
+            )
+        return self.create_request(
+            CommandName.ARGREP, *command_arguments, callback=ListCallback[int]()
+        )
+
+    @overload
+    def arinfo(self, key: KeyT, *, full: Literal[True]) -> CommandRequest[ArrayInfoFull]: ...
+
+    @overload
+    def arinfo(self, key: KeyT) -> CommandRequest[ArrayInfo]: ...
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARINFO,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def arinfo(self, key: KeyT, *, full: bool = False) -> CommandRequest[ArrayInfo | ArrayInfoFull]:
+        """
+        Gets the value at an index in an array.
+
+        :param key: The name of the key that holds the array.
+        :param full: Include per-slice statistics in the reply: the number of dense and
+         sparse slices and their average sizes and fill rates. Raises the complexity
+         from O(1) to O(N) where N is the number of slices.
+
+        :return: The value at the given index, or ``None`` if the index does not exist.
+        """
+        command_arguments: CommandArgList = [Key(key)]
+        if full:
+            command_arguments.append(PureToken.FULL)
+
+        return self.create_request(
+            CommandName.ARINFO, *command_arguments, callback=NoopCallback[ArrayInfo]()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARINSERT,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arinsert(self, key: KeyT, values: Parameters[ValueT]) -> CommandRequest[int]:
+        """
+        Inserts one or more values at consecutive indices.
+
+        :param key: The name of the key that holds the array.
+        :param values: One or more string values to insert at consecutive indices,
+         beginning at the current insert cursor position. The cursor advances by one for
+         each value inserted. Use ARNEXT to inspect the current cursor position and
+         ARSEEK to reposition it.
+
+        :return: The last index where a value was inserted.
+        """
+
+        return self.create_request(CommandName.ARINSERT, Key(key), *values, callback=IntCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARLASTITEMS,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def arlastitems(
+        self, key: KeyT, count: int, rev: bool = False
+    ) -> CommandRequest[tuple[AnyStr, ...]]:
+        """
+        Returns the most recently inserted elements.
+
+        :param key: The name of the key that holds the array.
+        :param count: The maximum number of most recently inserted elements to return.
+         If the array contains fewer elements than count, all elements are returned.
+        :param rev: When present, returns elements in reverse chronological order (most
+         recent first) instead of the default oldest-first order.
+        """
+        command_arguments: CommandArgList = [Key(key), count]
+        if rev:
+            command_arguments.append(PureToken.REV)
+
+        return self.create_request(
+            CommandName.ARLASTITEMS, *command_arguments, callback=TupleCallback[AnyStr]()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARLEN,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arlen(self, key: KeyT) -> CommandRequest[int]:
+        """
+        Returns the length of an array (max index + 1).
+
+        :param key: The name of the key that holds the array.
+        """
+
+        return self.create_request(CommandName.ARLEN, Key(key), callback=IntCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARMGET,
+        group=CommandGroup.ARRAY,
+        cacheable=True,
+        flags={CommandFlag.FAST, CommandFlag.READONLY},
+        version_introduced="8.8.0",
+    )
+    def armget(
+        self, key: KeyT, indices: Parameters[int]
+    ) -> CommandRequest[tuple[AnyStr | None, ...]]:
+        """
+        Gets values at multiple indices in an array.
+
+        :param key: The name of the key that holds the array.
+        :param indices: One or more zero-based integer indices of the elements to
+         retrieve. The reply preserves the order of the requested indices and returns
+         nil for any index that is not set.
+        """
+
+        return self.create_request(
+            CommandName.ARMGET, Key(key), *indices, callback=TupleCallback[AnyStr | None]()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARMSET,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def armset(self, key: KeyT, indices: Mapping[int, ValueT]) -> CommandRequest[int]:
+        """
+        Sets multiple index-value pairs in an array.
+
+        :param key: The name of the key that holds the array.
+        :param indices: One or more index value pairs. Each index is a zero-based
+         integer specifying where to write, and each value is the string to store at
+         that position. Pairs may be non-contiguous and in any order.
+
+        :return: Number of new slots that were set (previously empty).
+        """
+
+        return self.create_request(
+            CommandName.ARMSET, Key(key), *dict_to_flat_list(indices), callback=IntCallback()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARNEXT,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arnext(self, key: KeyT) -> CommandRequest[int | None]:
+        """
+        Returns the next index ARINSERT would use.
+
+        :param key: The name of the key that holds the array.
+
+        :return: The next index ARINSERT would use. Returns 0 for missing keys or when
+         no insert happened yet. Null when the insertion cursor is exhausted (next
+         insert would overflow).
+        """
+
+        return self.create_request(CommandName.ARNEXT, Key(key), callback=OptionalIntCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARSEEK,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arseek(self, key: KeyT, index: int) -> CommandRequest[bool]:
+        """
+        Sets the ARINSERT / ARRING cursor to a specific index.
+
+        :param key: The name of the key that holds the array.
+        :param index: The zero-based integer index to set as the new insert cursor
+         position for subsequent ARINSERT calls.
+
+        :return: True if the cursor was set, False if the key does not exist.
+        """
+
+        return self.create_request(CommandName.ARSEEK, Key(key), index, callback=BoolCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARRING,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def arring(self, key: KeyT, size: int, values: Parameters[ValueT]) -> CommandRequest[int]:
+        """
+        Inserts one or more values at consecutive indices.
+
+        :param key: The name of the key that holds the array.
+        :param size: The size of the ring buffer window. Each value is inserted at
+         insert_idx % size, wrapping back to index 0 when the end of the window is
+         reached. When the buffer is full, newer values overwrite older ones. If size is
+         smaller than the current window, the array is truncated to fit.
+        :param values: One or more string values to insert into the ring buffer. Each
+         value is placed at the next position in the ring and the cursor advances
+         accordingly.
+
+        :return: The last index where a value was inserted.
+        """
+
+        return self.create_request(
+            CommandName.ARRING, Key(key), size, *values, callback=IntCallback()
+        )
+
+    @mutually_exclusive_parameters("op", "match", required=True)
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.AROP,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def arop(
+        self,
+        key: KeyT,
+        start: int,
+        end: int,
+        *,
+        op: Literal[
+            PureToken.SUM,
+            PureToken.MIN,
+            PureToken.MAX,
+            PureToken.AND,
+            PureToken.OR,
+            PureToken.XOR,
+            PureToken.USED,
+            PureToken.SUM,
+        ]
+        | None = None,
+        match: StringT | None = None,
+    ) -> CommandRequest[int | AnyStr | None]:
+        """
+        Performs aggregate operations on array elements in a range.
+
+        :param key: The name of the key that holds the array.
+        :param start: The zero-based integer index of the first element in the range to
+         aggregate.
+        :param end: The zero-based integer index of the last element in the range to
+         aggregate (inclusive). The command always scans from the lower to the higher
+         index regardless of argument order.
+        :param op: The aggregate function to apply to all non-empty elements in [start,
+         end]. One of:
+         SUM — Returns the sum of all numeric values as a bulk string.
+         MIN — Returns the minimum numeric value as a bulk string.
+         MAX — Returns the maximum numeric value as a bulk string.
+         AND — Returns the bitwise AND of all values, treating each as an integer.
+         OR — Returns the bitwise OR of all values, treating each as an integer.
+         XOR — Returns the bitwise XOR of all values, treating each as an integer.
+         USED — Returns the count of non-empty elements in the range.
+         SUM, MIN, and MAX return nil when no numeric elements are present in the range.
+         AND, OR, and XOR return nil when the range is empty.
+        :param match: Returns the count of elements whose value equals value.
+
+        :return: Result of the operation. Null if no elements match the operation.
+        """
+        command_arguments: CommandArgList = [Key(key), start, end]
+        if match is not None:
+            command_arguments.extend([PureToken.MATCH, match])
+        if op is not None:
+            command_arguments.append(op)
+
+        return self.create_request(CommandName.AROP, *command_arguments, callback=NoopCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARSCAN,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+        version_introduced="8.8.0",
+    )
+    def arscan(
+        self,
+        key: KeyT,
+        start: int,
+        end: int,
+        limit: int | None = None,
+    ) -> CommandRequest[list[tuple[int, AnyStr]]]:
+        """
+        Incrementally iterate over members of a set using a cursor.
+
+        :param key: The name of the key that holds the array.
+        :param start: The zero-based integer index at which to begin scanning. If start
+         is greater than end, elements are returned in reverse index order.
+        :param end: The zero-based integer index at which to stop scanning (inclusive).
+        :param limit: The maximum number of index-value pairs to return. When omitted,
+         all elements in the range are returned. Unlike ARGETRANGE, empty slots are not
+         included in the output, so LIMIT caps the number of existing elements returned.
+
+        :return: A tuple of (index, value) pairs.
+        """
+        command_arguments: CommandArgList = [Key(key), start, end]
+        if limit is not None:
+            command_arguments.extend([PureToken.LIMIT, limit])
+
+        return self.create_request(
+            CommandName.ARSCAN, *command_arguments, callback=ListOfTuplesCallback[int, AnyStr]()
         )

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -5039,7 +5039,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         self,
         keys: Parameters[KeyT],
         weights: Parameters[int] | None = None,
-        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM] | None = None,
+        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM, PureToken.COUNT]
+        | None = None,
         withscores: bool | None = None,
     ) -> CommandRequest[tuple[AnyStr | ScoredMember, ...]]:
         """
@@ -5066,7 +5067,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         keys: Parameters[KeyT],
         destination: KeyT,
         weights: Parameters[int] | None = None,
-        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM] | None = None,
+        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM, PureToken.COUNT]
+        | None = None,
     ) -> CommandRequest[int]:
         """
         Compute sorted set intersection and store the result in destination.
@@ -5770,7 +5772,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         self,
         keys: Parameters[KeyT],
         weights: Parameters[int] | None = None,
-        aggregate: Literal[PureToken.SUM, PureToken.MIN, PureToken.MAX] | None = None,
+        aggregate: Literal[PureToken.SUM, PureToken.MIN, PureToken.MAX, PureToken.COUNT]
+        | None = None,
         withscores: bool | None = None,
     ) -> CommandRequest[tuple[AnyStr | ScoredMember, ...]]:
         """
@@ -5797,7 +5800,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         keys: Parameters[KeyT],
         destination: KeyT,
         weights: Parameters[int] | None = None,
-        aggregate: Literal[PureToken.SUM, PureToken.MIN, PureToken.MAX] | None = None,
+        aggregate: Literal[PureToken.SUM, PureToken.MIN, PureToken.MAX, PureToken.COUNT]
+        | None = None,
     ) -> CommandRequest[int]:
         """
         Compute the union of sorted sets and store the result at destination.
@@ -5898,7 +5902,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         *,
         destination: Key | None = ...,
         weights: Parameters[int] | None = ...,
-        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM] | None = ...,
+        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM, PureToken.COUNT]
+        | None = ...,
         withscores: bool | None = ...,
     ) -> CommandRequest[int]: ...
 
@@ -5913,7 +5918,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         *,
         destination: Key | None = ...,
         weights: Parameters[int] | None = ...,
-        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM] | None = ...,
+        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM, PureToken.COUNT]
+        | None = ...,
         withscores: bool | None = ...,
     ) -> CommandRequest[tuple[AnyStr | ScoredMember, ...]]: ...
 
@@ -5929,7 +5935,8 @@ class CoreCommands(CommandMixin[AnyStr]):
         *,
         destination: Key | None = None,
         weights: Parameters[int] | None = None,
-        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM] | None = None,
+        aggregate: Literal[PureToken.MAX, PureToken.MIN, PureToken.SUM, PureToken.COUNT]
+        | None = None,
         withscores: bool | None = None,
     ) -> CommandRequest[int] | CommandRequest[tuple[AnyStr | ScoredMember, ...]]:
         command_arguments: CommandArgList = []

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -388,6 +388,68 @@ class CoreCommands(CommandMixin[AnyStr]):
             CommandName.INCRBYFLOAT, Key(key), increment, callback=FloatCallback()
         )
 
+    @mutually_exclusive_parameters("ex", "px", "exat", "pxat", "persist")
+    @redis_command(CommandName.INCREX, group=CommandGroup.STRING, flags={CommandFlag.FAST})
+    def increx(
+        self,
+        key: KeyT,
+        *,
+        increment: int | float | None = None,
+        saturate: bool = False,
+        lowerbound: int | float | None = None,
+        upperbound: int | float | None = None,
+        ex: int | datetime.timedelta | None = None,
+        px: int | datetime.timedelta | None = None,
+        exat: int | datetime.datetime | None = None,
+        pxat: int | datetime.datetime | None = None,
+        persist: bool | None = None,
+        enx: bool = False,
+    ) -> CommandRequest[tuple[float, ...]]:
+        """
+        Increment the float value of a key by the given amount.
+
+        :param key: The key name.
+        :param increment: The amount to add.
+        :return: The value of the key after the increment (increment if key did not exist).
+        """
+        command_arguments: CommandArgList = []
+        if increment is not None:
+            command_arguments.extend(
+                [
+                    PrefixToken.BYFLOAT if isinstance(increment, float) else PrefixToken.BYINT,
+                    increment,
+                ]
+            )
+        if saturate:
+            command_arguments.append(PureToken.SATURATE)
+        if lowerbound is not None:
+            command_arguments.extend([PrefixToken.LBOUND, lowerbound])
+        if upperbound is not None:
+            command_arguments.extend([PrefixToken.UBOUND, upperbound])
+        if ex is not None:
+            command_arguments.append(PrefixToken.EX)
+            command_arguments.append(normalized_seconds(ex))
+        if px is not None:
+            command_arguments.append(PrefixToken.PX)
+            command_arguments.append(normalized_milliseconds(px))
+        if exat is not None:
+            command_arguments.append(PrefixToken.EXAT)
+            command_arguments.append(normalized_time_seconds(exat))
+        if pxat is not None:
+            command_arguments.append(PrefixToken.PXAT)
+            command_arguments.append(normalized_time_milliseconds(pxat))
+        if persist:
+            command_arguments.append(PureToken.PERSIST)
+        if enx:
+            command_arguments.append(PureToken.ENX)
+
+        return self.create_request(
+            CommandName.INCREX,
+            Key(key),
+            *command_arguments,
+            callback=TupleCallback[float](),
+        )
+
     @overload
     def lcs(
         self,
@@ -5823,6 +5885,39 @@ class CoreCommands(CommandMixin[AnyStr]):
             CommandName.XACK, Key(key), group, *identifiers, callback=IntCallback()
         )
 
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.XNACK,
+        version_introduced="8.8.0",
+        group=CommandGroup.STREAM,
+        flags={CommandFlag.FAST},
+    )
+    def xnack(
+        self,
+        key: KeyT,
+        group: StringT,
+        mode: Literal[PureToken.SILENT, PureToken.FAIL, PureToken.FATAL],
+        identifiers: Parameters[ValueT],
+        *,
+        retrycount: int | None = None,
+        force: bool = False,
+    ) -> CommandRequest[int]:
+        """
+        Releases pending messages back to the PEL without acknowledging them and resets
+        the idle timeouts, making the messages immediately available for re-delivery.
+
+        :return: The number of messages successfully released back to the group PEL.
+        """
+        command_arguments: CommandArgList = [PrefixToken.IDS, len(list(identifiers)), *identifiers]
+        if retrycount is not None:
+            command_arguments.extend([PrefixToken.RETRYCOUNT, retrycount])
+        if force:
+            command_arguments.append(PureToken.FORCE)
+
+        return self.create_request(
+            CommandName.XNACK, Key(key), group, mode, *command_arguments, callback=IntCallback()
+        )
+
     @versionadded(version="5.2.0")
     @redis_command(
         CommandName.XACKDEL,
@@ -9026,7 +9121,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         """
         command_arguments: CommandArgList = [Key(key)]
         if reduce is not None:
-            command_arguments.extend([PureToken.REDUCE, reduce])
+            command_arguments.extend([PureToken.REDUCE_TOKEN, reduce])
 
         if isinstance(values, bytes):
             command_arguments.extend([PureToken.FP32, values])
@@ -9324,7 +9419,6 @@ class CoreCommands(CommandMixin[AnyStr]):
         :param element: The element to set the attributes for
         :param attributes: JSON serializable values to set as attributes
 
-
         :return: ``True`` if the attributes were successfully set
         """
         command_arguments: CommandArgList = [Key(key), element]
@@ -9368,7 +9462,6 @@ class CoreCommands(CommandMixin[AnyStr]):
         :param key: The key containing the vector set
         :param count: The number of random elements to return
 
-
         :return: A random element, or a tuple of elements if count is specified; negative count allows duplicates.
         """
         command_arguments: CommandArgList = [Key(key)]
@@ -9387,7 +9480,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         self, key: KeyT, start: StringT, end: StringT, count: int | None = None
     ) -> CommandRequest[tuple[AnyStr, ...]]:
         """
-        Retreives all elements inside a vector set (optionally, in small
+        Retrieves all elements inside a vector set (optionally, in small
         batches with the use of :paramref:`count`)
 
         :param key: The key containing the vector set
@@ -9416,12 +9509,140 @@ class CoreCommands(CommandMixin[AnyStr]):
 
         :param key: The key containing the vector set
         :param element: The element to check for membership
-
-
         """
         return self.create_request(
             CommandName.VISMEMBER,
             Key(key),
             element,
             callback=BoolCallback(),
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARCOUNT,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.READONLY, CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arcount(self, key: KeyT) -> CommandRequest[int]:
+        """
+        Returns the number of non-empty elements in an array.
+
+        :param key: The name of the key that holds the array.
+        """
+
+        return self.create_request(CommandName.ARCOUNT, Key(key), callback=IntCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARSET,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.FAST},
+        version_introduced="8.8.0",
+    )
+    def arset(self, key: KeyT, index: int, values: Parameters[ValueT]) -> CommandRequest[int]:
+        """
+        Sets one or more contiguous values starting at an index in an array.
+
+        :param key: The name of the key that holds the array.
+        :param index: The zero-based integer index at which to start writing. When
+         multiple values are provided, they are stored at consecutive indices starting
+         from index.
+        :param values: One or more string values to store at consecutive indices
+         beginning at index.
+
+        :return: The number of new (previously empty) slots filled is returned.
+        """
+
+        return self.create_request(
+            CommandName.ARSET, Key(key), index, *values, callback=IntCallback()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARDEL,
+        group=CommandGroup.ARRAY,
+        flags={CommandFlag.FAST},
+    )
+    def ardel(self, key: KeyT, indices: Parameters[ValueT]) -> CommandRequest[int]:
+        """
+        Deletes elements at the specified indices in an array.
+
+        :param key: The name of the key that holds the array.
+        :param indices: One or more zero-based integer indices of the elements to
+         delete. Deleting an index that does not exist counts as zero elements deleted
+         and does not modify the array.
+
+        :return: Number of elements deleted.
+        """
+
+        return self.create_request(CommandName.ARDEL, Key(key), *indices, callback=IntCallback())
+
+    @versionadded(version="6.8.0")
+    @redis_command(CommandName.ARDELRANGE, group=CommandGroup.ARRAY, flags={CommandFlag.SLOW})
+    def ardelrange(
+        self, key: KeyT, ranges: Parameters[tuple[ValueT, ValueT]]
+    ) -> CommandRequest[int]:
+        """
+        Deletes elements in one or more ranges.
+
+        :param key: The name of the key that holds the array.
+        :param ranges: One or more start/end pairs, each defining an inclusive range of
+         indices to delete. If start is greater than end for a given pair, the range is
+         processed in ascending order regardless. Multiple pairs may overlap; each
+         element is counted at most once.
+
+        :return: Number of elements deleted.
+        """
+        command_arguments: CommandArgList = []
+        for _range in ranges:
+            command_arguments.extend(_range)
+        if not command_arguments:
+            raise DataError("ARDELRANGE needs at least one range to delete")
+
+        return self.create_request(
+            CommandName.ARDELRANGE, Key(key), *command_arguments, callback=IntCallback()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARGET,
+        group=CommandGroup.ARRAY,
+        cacheable=True,
+        flags={CommandFlag.FAST, CommandFlag.READONLY},
+    )
+    def arget(self, key: KeyT, index: int) -> CommandRequest[AnyStr | None]:
+        """
+        Gets the value at an index in an array.
+
+        :param key: The name of the key that holds the array.
+        :param index: The zero-based integer index of the element to retrieve.
+        :return: The value at the given index, or ``None`` if the index does not exist.
+        """
+
+        return self.create_request(
+            CommandName.ARGET, Key(key), index, callback=OptionalAnyStrCallback[AnyStr]()
+        )
+
+    @versionadded(version="6.8.0")
+    @redis_command(
+        CommandName.ARGETRANGE,
+        group=CommandGroup.ARRAY,
+        cacheable=True,
+        flags={CommandFlag.READONLY, CommandFlag.SLOW},
+    )
+    def argetrange(self, key: KeyT, start: int, end: int) -> CommandRequest[list[AnyStr]]:
+        """
+        Gets values in a range of indices.
+
+        :param key: The name of the key that holds the array.
+        :param start: The zero-based integer index of the first element to return. If
+         start is greater than end, elements are returned in reverse index order.
+        :param end: The zero-based integer index of the last element to return
+         (inclusive). If end is less than start, elements are returned in reverse index
+         order.
+        """
+
+        return self.create_request(
+            CommandName.ARGETRANGE, Key(key), start, end, callback=ListCallback[AnyStr]()
         )

--- a/coredis/commands/core.py
+++ b/coredis/commands/core.py
@@ -466,10 +466,50 @@ class CoreCommands(CommandMixin[AnyStr]):
         enx: bool = False,
     ) -> CommandRequest[tuple[float, ...]]:
         """
-        Increment the float value of a key by the given amount.
+        Increments or decrements the numeric value stored at key by the specified
+        amount, with optional upper/lower bounds and expiration control, in a single
+        atomic operation. If the key does not exist, it is set to 0 before performing
+        the operation. An error is returned if the key contains a value of the wrong
+        type or a string that cannot be interpreted as a number.
 
-        :param key: The key name.
-        :param increment: The amount to add.
+        Unlike INCR and INCRBY, INCREX returns an array of two elements: the new value
+        of the key after the increment, and the increment that was actually applied.
+        When the computed result would fall outside an explicit LBOUND/UBOUND or the
+        type limits, the default is to skip the operation and reply with [current_value,
+        0], leaving the key and its TTL untouched. The SATURATE flag changes this
+        behavior so the result is capped at the bound instead.
+
+        :param key: The name of the key to increment.
+        :param increment: Specifies the increment amount, defaults to 1
+        :param saturate: When specified, an out-of-bounds result is capped at UBOUND or
+         floored at LBOUND (or saturated to the type limits when no explicit bound is
+         given). The second element of the reply reflects the saturated delta. An error
+         is returned if the delta cannot be represented as a 64-bit signed integer in
+         integer mode, or would produce Infinity in BYFLOAT mode. Any expiration option
+         is still applied as specified.
+        :param lowerbound: Sets a lower bound for the resulting value. If the computed
+         result would fall below lowerbound, the operation is skipped and the reply is
+         [current_value, 0] (or use the SATURATE flag to floor the result at lowerbound
+         instead). When omitted, the bound is LLONG_MIN in integer mode or -LDBL_MAX in
+         BYFLOAT mode. LBOUND must be less than or equal to UBOUND when both are
+         specified.
+        :param upperbound: Sets an upper bound for the resulting value. If the computed
+         result would exceed upperbound, the operation is skipped and the reply is
+         [current_value, 0] (or use the SATURATE flag to cap the result at upperbound
+         instead). When omitted, the bound is LLONG_MAX in integer mode or LDBL_MAX in
+         BYFLOAT mode. UBOUND must be greater than or equal to LBOUND when both are
+         specified.
+        :param ex: set the specified expiration time in seconds.
+        :param px: set the specified expiration time in milliseconds.
+        :param exat: set a Unix time in seconds at which the key will expire.
+        :param pxat: set a Unix time in milliseconds at which the key will expire.
+        :param persist: remove the expiration associated with the key.
+        :param enx: Only sets the TTL/expiration if the key currently has no TTL/
+         expiration. If the key already has a TTL, the increment is still applied but
+         the TTL is left unchanged. ENX can ensure that a window counter rate limiter's
+         TTL is set only when it is created, and not reset on subsequent token requests.
+         ENX must be combined with EX/PX/EXAT/PXAT and is incompatible with PERSIST.
+
         :return: The value of the key after the increment (increment if key did not exist).
         """
         command_arguments: CommandArgList = []
@@ -5966,6 +6006,29 @@ class CoreCommands(CommandMixin[AnyStr]):
         Releases pending messages back to the PEL without acknowledging them and resets
         the idle timeouts, making the messages immediately available for re-delivery.
 
+        :param key: Name of the stream.
+        :param group: Name of the consumer group.
+        :param mode: Controls the delivery counter adjustment. Must be one of:
+         SILENT: Decrements the delivery counter by 1, essentially "undoing" the
+         delivery increment. Use this for an internal failure on the consumer side while
+         processing the message or graceful shutdown where the delivery "didn't count".
+         FAIL: Keeps the current delivery counter value unchanged. Use this when the
+         current consumer failed to process this message (for example, due to memory
+         constraints). The root cause may be the message or the consumer (it is
+         unclear), so the best strategy would be to let another consumer try to process
+         the message.
+         FATAL: Sets the delivery counter to the maximum value (LLONG_MAX or ~9.22e18),
+         marking the message as permanently failed. Use this for invalid or suspected
+         malicious messages.
+        :param identifiers: message IDs to release.
+        :param retrycount: Directly sets the delivery counter to the specified value,
+         overriding the mode-based adjustment. This gives explicit control over the
+         retry counter regardless of the mode selected.
+        :param force: Creates new unowned PEL entries for IDs that are not already in
+         the group PEL. Each entry must exist in the stream. When FORCE creates an
+         entry, the delivery counter is set to 0 (or to RETRYCOUNT if specified, or to
+         LLONG_MAX if mode is FATAL).
+
         :return: The number of messages successfully released back to the group PEL.
         """
         command_arguments: CommandArgList = [PrefixToken.IDS, len(list(identifiers)), *identifiers]
@@ -9739,7 +9802,7 @@ class CoreCommands(CommandMixin[AnyStr]):
         limit: int | None = ...,
         withvalues: Literal[True],
         nocase: bool = ...,
-    ) -> CommandRequest[list[tuple[int, StringT]]]: ...
+    ) -> CommandRequest[list[tuple[int, AnyStr]]]: ...
 
     @versionadded(version="6.8.0")
     @redis_command(

--- a/coredis/modules/json.py
+++ b/coredis/modules/json.py
@@ -170,6 +170,7 @@ class Json(ModuleGroup[AnyStr]):
         group=COMMAND_GROUP,
         version_introduced="1.0.0",
         module=MODULE,
+        arguments={"fpha": {"version_introduced": "8.8.0"}},
     )
     def set(
         self,
@@ -177,6 +178,7 @@ class Json(ModuleGroup[AnyStr]):
         path: RedisValueT,
         value: JsonType,
         condition: Literal[PureToken.NX, PureToken.XX] | None = None,
+        fpha: Literal[PureToken.FP16, PureToken.BF16, PureToken.FP32, PureToken.FP64] | None = None,
     ) -> CommandRequest[bool]:
         """
         Sets or updates the JSON value at a path
@@ -194,11 +196,14 @@ class Json(ModuleGroup[AnyStr]):
         :param condition: Optional argument to modify the behavior of adding a key to a JSON Object.
          If ``NX``, the key is set only if it does not already exist. If ``XX``, the key is set only
          if it already exists.
+        :param fpha: Force floating point homogeneous arrays (FPHAs) to use a specified FP type.
         :return: `True` if the value was set successfully, `False` otherwise.
         """
         command_arguments: CommandArgList = [Key(key), path, json.dumps(value)]
-        if condition:
+        if condition is not None:
             command_arguments.append(condition)
+        if fpha is not None:
+            command_arguments.extend(["FPHA", fpha])
         return self.client.create_request(
             CommandName.JSON_SET, *command_arguments, callback=SimpleStringCallback()
         )

--- a/coredis/modules/search.py
+++ b/coredis/modules/search.py
@@ -211,7 +211,7 @@ class Group:
             bies: list[StringT] = list(self.by)
             args.extend([len(bies), *bies])
         for reducer in self.reducers or []:
-            args.append(PureToken.REDUCE)
+            args.append(PureToken.REDUCE_TOKEN)
             args.extend(reducer.args)
 
         return args

--- a/coredis/modules/search.py
+++ b/coredis/modules/search.py
@@ -1130,6 +1130,7 @@ class Search(ModuleGroup[AnyStr]):
         module=MODULE,
         version_introduced="8.4.0",
         group=COMMAND_GROUP,
+        arguments={"shard_k_ratio": {"version_introduced": "8.8.0"}},
     )
     def hybrid(
         self,
@@ -1142,6 +1143,7 @@ class Search(ModuleGroup[AnyStr]):
         search_score_alias: StringT | None = None,
         k: int | None = None,
         ef_runtime: int | None = None,
+        shard_k_ratio: float | None = None,
         radius: int | None = None,
         epsilon: float | None = None,
         vector_score_alias: StringT | None = None,
@@ -1167,6 +1169,8 @@ class Search(ModuleGroup[AnyStr]):
         :param search_score_alias: Alias for the search score
         :param k: K value for performing K-nearest neighbour search
         :param ef_runtime: controls the range search accuracy vs. speed tradeoff.
+        :param shard_k_ratio: controls the number of results each shard retrieves
+         relative to the requested top_k in cluster setups.
         :param radius: maximum distance for range matches
         :param epsilon: precision controls for range matches
         :param vector_score_alias: Alias for the vector search score
@@ -1198,6 +1202,8 @@ class Search(ModuleGroup[AnyStr]):
             _knn_args: CommandArgList = [PrefixToken.K, k]
             if ef_runtime:
                 _knn_args.extend([PrefixToken.EF_RUNTIME, ef_runtime])
+            if shard_k_ratio is not None:
+                _knn_args.extend([PrefixToken.SHARD_K_RATIO, shard_k_ratio])
 
             command_arguments.extend([PureToken.KNN, len(_knn_args), *_knn_args])
         if radius is not None:

--- a/coredis/modules/timeseries.py
+++ b/coredis/modules/timeseries.py
@@ -55,6 +55,25 @@ def normalized_timestamp(ts: int | datetime | StringT) -> StringT | int:
     return normalized_time_milliseconds(ts)
 
 
+Aggregator = Literal[
+    PureToken.AVG,
+    PureToken.COUNT,
+    PureToken.FIRST,
+    PureToken.LAST,
+    PureToken.MAX,
+    PureToken.MIN,
+    PureToken.RANGE,
+    PureToken.STD_P,
+    PureToken.STD_S,
+    PureToken.SUM,
+    PureToken.TWA,
+    PureToken.VAR_P,
+    PureToken.VAR_S,
+    PureToken.COUNTALL,
+    PureToken.COUNTNAN,
+]
+
+
 class RedisTimeSeries(Module[AnyStr]):
     NAME = "timeseries"
     FULL_NAME = "RedisTimeSeries"
@@ -520,26 +539,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         min_value: int | float | None = None,
         max_value: int | float | None = None,
         count: int | None = None,
-        aggregator: None
-        | (
-            Literal[
-                PureToken.AVG,
-                PureToken.COUNT,
-                PureToken.FIRST,
-                PureToken.LAST,
-                PureToken.MAX,
-                PureToken.MIN,
-                PureToken.RANGE,
-                PureToken.STD_P,
-                PureToken.STD_S,
-                PureToken.SUM,
-                PureToken.TWA,
-                PureToken.VAR_P,
-                PureToken.VAR_S,
-                PureToken.COUNTALL,
-                PureToken.COUNTNAN,
-            ]
-        ) = None,
+        aggregator: None | Aggregator | Parameters[Aggregator] = None,
         bucketduration: int | timedelta | None = None,
         align: int | StringT | None = None,
         buckettimestamp: StringT | None = None,
@@ -559,6 +559,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         :param max_value: Maximum value to filter samples by.
         :param count: Limits the number of returned samples.
         :param aggregator: Aggregates samples into time buckets by the provided aggregation type.
+         Redis 8.8+ supports multiple aggregators.
         :param bucketduration: Duration of each bucket in milliseconds.
         :param align: Time bucket alignment control for :paramref:`aggregator`.
         :param buckettimestamp: Timestamp of the first bucket.
@@ -587,10 +588,11 @@ class TimeSeries(ModuleGroup[AnyStr]):
         if aggregator and bucketduration is not None:
             if align is not None:
                 command_arguments.extend([PrefixToken.ALIGN, align])
+            _agg = aggregator if isinstance(aggregator, PureToken) else b",".join(aggregator)
             command_arguments.extend(
                 [
                     PrefixToken.AGGREGATION,
-                    aggregator,
+                    _agg,
                     normalized_milliseconds(bucketduration),
                 ]
             )
@@ -627,26 +629,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         min_value: int | float | None = None,
         max_value: int | float | None = None,
         count: int | None = None,
-        aggregator: None
-        | (
-            Literal[
-                PureToken.AVG,
-                PureToken.COUNT,
-                PureToken.FIRST,
-                PureToken.LAST,
-                PureToken.MAX,
-                PureToken.MIN,
-                PureToken.RANGE,
-                PureToken.STD_P,
-                PureToken.STD_S,
-                PureToken.SUM,
-                PureToken.TWA,
-                PureToken.VAR_P,
-                PureToken.VAR_S,
-                PureToken.COUNTALL,
-                PureToken.COUNTNAN,
-            ]
-        ) = None,
+        aggregator: None | Aggregator | Parameters[Aggregator] = None,
         bucketduration: int | timedelta | None = None,
         align: int | StringT | None = None,
         buckettimestamp: StringT | None = None,
@@ -666,6 +649,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         :param max_value: Maximum value to filter samples by.
         :param count: Limit the number of returned samples.
         :param aggregator: Aggregates samples into time buckets by the provided aggregation type.
+         Redis 8.8+ supports multiple aggregators.
         :param bucketduration: Duration of each bucket in milliseconds.
         :param align: Time bucket alignment control for :paramref:`aggregator`.
         :param buckettimestamp: Timestamp for the first bucket.
@@ -691,10 +675,11 @@ class TimeSeries(ModuleGroup[AnyStr]):
         if aggregator and bucketduration is not None:
             if align is not None:
                 command_arguments.extend([PrefixToken.ALIGN, align])
+            _agg = aggregator if isinstance(aggregator, PureToken) else b",".join(aggregator)
             command_arguments.extend(
                 [
                     PrefixToken.AGGREGATION,
-                    aggregator,
+                    _agg,
                     normalized_milliseconds(bucketduration),
                 ]
             )
@@ -738,26 +723,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         selected_labels: Parameters[StringT] | None = None,
         count: int | None = None,
         align: int | StringT | None = None,
-        aggregator: None
-        | (
-            Literal[
-                PureToken.AVG,
-                PureToken.COUNT,
-                PureToken.FIRST,
-                PureToken.LAST,
-                PureToken.MAX,
-                PureToken.MIN,
-                PureToken.RANGE,
-                PureToken.STD_P,
-                PureToken.STD_S,
-                PureToken.SUM,
-                PureToken.TWA,
-                PureToken.VAR_P,
-                PureToken.VAR_S,
-                PureToken.COUNTALL,
-                PureToken.COUNTNAN,
-            ]
-        ) = None,
+        aggregator: None | Aggregator | Parameters[Aggregator] = None,
         bucketduration: int | timedelta | None = None,
         buckettimestamp: StringT | None = None,
         groupby: StringT | None = None,
@@ -808,6 +774,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         :param count: Limit the number of samples returned.
         :param align: Time bucket alignment control for :paramref:`aggregator`.
         :param aggregator: Aggregates samples into time buckets by the provided aggregation type.
+         Redis 8.8+ supports multiple aggregators.
         :param bucketduration: Duration of each bucket, in milliseconds.
         :param buckettimestamp: Timestamp of the first bucket.
         :param groupby: Label to group the samples by
@@ -839,10 +806,11 @@ class TimeSeries(ModuleGroup[AnyStr]):
             if align is not None:
                 command_arguments.extend([PrefixToken.ALIGN, align])
             if aggregator and bucketduration is not None:
+                _agg = aggregator if isinstance(aggregator, PureToken) else b",".join(aggregator)
                 command_arguments.extend(
                     [
                         PrefixToken.AGGREGATION,
-                        aggregator,
+                        _agg,
                         normalized_milliseconds(bucketduration),
                     ]
                 )
@@ -892,26 +860,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         selected_labels: Parameters[StringT] | None = None,
         count: int | None = None,
         align: int | StringT | None = None,
-        aggregator: None
-        | (
-            Literal[
-                PureToken.AVG,
-                PureToken.COUNT,
-                PureToken.FIRST,
-                PureToken.LAST,
-                PureToken.MAX,
-                PureToken.MIN,
-                PureToken.RANGE,
-                PureToken.STD_P,
-                PureToken.STD_S,
-                PureToken.SUM,
-                PureToken.TWA,
-                PureToken.VAR_P,
-                PureToken.VAR_S,
-                PureToken.COUNTALL,
-                PureToken.COUNTNAN,
-            ]
-        ) = None,
+        aggregator: None | Aggregator | Parameters[Aggregator] = None,
         bucketduration: int | timedelta | None = None,
         buckettimestamp: StringT | None = None,
         groupby: StringT | None = None,
@@ -946,6 +895,7 @@ class TimeSeries(ModuleGroup[AnyStr]):
         :param count: Limit the number of samples returned.
         :param align: Time bucket alignment control for :paramref:`aggregator`.
         :param aggregator: Aggregates samples into time buckets by the provided aggregation type.
+         Redis 8.8+ supports multiple aggregators.
         :param bucketduration: Duration of each bucket, in milliseconds.
         :param buckettimestamp: Timestamp of the first bucket.
         :param groupby: Label to group the samples by
@@ -977,10 +927,11 @@ class TimeSeries(ModuleGroup[AnyStr]):
             if align is not None:
                 command_arguments.extend([PrefixToken.ALIGN, align])
             if aggregator and bucketduration is not None:
+                _agg = aggregator if isinstance(aggregator, PureToken) else b",".join(aggregator)
                 command_arguments.extend(
                     [
                         PrefixToken.AGGREGATION,
-                        aggregator,
+                        _agg,
                         normalized_milliseconds(bucketduration),
                     ]
                 )

--- a/coredis/response/_callbacks/__init__.py
+++ b/coredis/response/_callbacks/__init__.py
@@ -510,3 +510,10 @@ class FirstValueCallback(ResponseCallback[dict[R, S], S]):
             return list(response.values())[0]
         else:
             raise ValueError("Empty response")
+
+
+class ListOfTuplesCallback(ResponseCallback[list[ResponseType], list[tuple[R, S]]]):
+    def transform(self, response: list[ResponseType], **options: Any) -> list[tuple[R, S]]:
+        if isinstance(response, list):
+            return [tuple(r) for r in response]  # type: ignore
+        raise ValueError(f"Unable to map {response!r} to list of tuples")

--- a/coredis/response/types.py
+++ b/coredis/response/types.py
@@ -357,3 +357,34 @@ class VectorData(TypedDict):
     l2_norm: float
     #: If the vector is quantized as q8, the quantization range
     quantization_range: float | None
+
+
+#: Details of an array
+#: See: `<https://redis.io/commands/arinfo>`__
+ArrayInfo = TypedDict(
+    "ArrayInfo",
+    {
+        "count": int,
+        "len": int,
+        "next-insert-index": int,
+        "slices": int,
+        "directory-size": int,
+        "super-dir-entries": int,
+        "slice-size": int,
+    },
+)
+
+_ArrayInfoFull = TypedDict(
+    "_ArrayInfoFull",
+    {
+        "dense-slices": int,
+        "sparse-slices": int,
+        "avg-dense-size": float,
+        "avg-dense-fill": float,
+        "avg-sparse-size": float,
+    },
+)
+
+
+class ArrayInfoFull(ArrayInfo, _ArrayInfoFull):
+    pass

--- a/coredis/tokens.py
+++ b/coredis/tokens.py
@@ -82,10 +82,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``TS.ALTER``
     #:  - ``TS.CREATE``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     #:  - ``ZINTER``
     #:  - ``ZINTERSTORE``
     #:  - ``ZMPOP``
@@ -103,10 +99,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``TS.ALTER``
     #:  - ``TS.CREATE``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     #:  - ``ZINTER``
     #:  - ``ZINTERSTORE``
     #:  - ``ZMPOP``
@@ -123,10 +115,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``TS.ALTER``
     #:  - ``TS.CREATE``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     #:  - ``ZINTER``
     #:  - ``ZINTERSTORE``
     #:  - ``ZUNION``
@@ -164,14 +152,12 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #: Used by:
     #:
     #:  - ``BITFIELD``
-    #:  - ``INCREX``
     #:  - ``XNACK``
     FAIL = b"FAIL"
 
     #: Used by:
     #:
     #:  - ``BITFIELD``
-    #:  - ``INCREX``
     SAT = b"SAT"
 
     #: Used by:
@@ -651,7 +637,7 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #: Used by:
     #:
     #:  - ``INCREX``
-    REJECT = b"REJECT"
+    SATURATE = b"SATURATE"
 
     #: Used by:
     #:
@@ -836,10 +822,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``FT.AGGREGATE``
     #:  - ``FT.HYBRID``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     #:  - ``ZINTER``
     #:  - ``ZINTERSTORE``
     #:  - ``ZUNION``
@@ -876,6 +858,7 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
 
     #: Used by:
     #:
+    #:  - ``JSON.SET``
     #:  - ``VADD``
     #:  - ``VSIM``
     FP32 = b"FP32"
@@ -920,6 +903,21 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:
     #:  - ``VEMB``
     RAW = b"RAW"
+
+    #: Used by:
+    #:
+    #:  - ``JSON.SET``
+    BF16 = b"BF16"
+
+    #: Used by:
+    #:
+    #:  - ``JSON.SET``
+    FP16 = b"FP16"
+
+    #: Used by:
+    #:
+    #:  - ``JSON.SET``
+    FP64 = b"FP64"
 
     #: Used by:
     #:
@@ -1001,10 +999,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``TS.ALTER``
     #:  - ``TS.CREATE``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     FIRST = b"FIRST"
 
     #: Used by:
@@ -1013,10 +1007,6 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``TS.ALTER``
     #:  - ``TS.CREATE``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     LAST = b"LAST"
 
     #: Used by:
@@ -1032,83 +1022,47 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:  - ``FT.AGGREGATE``
     #:  - ``FT.HYBRID``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     AVG = b"AVG"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     COUNTALL = b"COUNTALL"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     COUNTNAN = b"COUNTNAN"
 
     #: Used by:
     #:
     #:  - ``FT.HYBRID``
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     RANGE = b"RANGE"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     STD_P = b"STD.P"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     STD_S = b"STD.S"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     TWA = b"TWA"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     VAR_P = b"VAR.P"
 
     #: Used by:
     #:
     #:  - ``TS.CREATERULE``
-    #:  - ``TS.MRANGE``
-    #:  - ``TS.MREVRANGE``
-    #:  - ``TS.RANGE``
-    #:  - ``TS.REVRANGE``
     VAR_S = b"VAR.S"
 
     #: Used by:
@@ -1398,6 +1352,12 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:
     #:  - ``FT.AGGREGATE``
     #:  - ``FT.HYBRID``
+    COLLECT_TOKEN = b"COLLECT"
+
+    #: Used by:
+    #:
+    #:  - ``FT.AGGREGATE``
+    #:  - ``FT.HYBRID``
     COUNT_DISTINCT = b"COUNT_DISTINCT"
 
     #: Used by:
@@ -1410,7 +1370,19 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:
     #:  - ``FT.AGGREGATE``
     #:  - ``FT.HYBRID``
+    FIELDSALL = b"FIELDS *"
+
+    #: Used by:
+    #:
+    #:  - ``FT.AGGREGATE``
+    #:  - ``FT.HYBRID``
     FIRST_VALUE = b"FIRST_VALUE"
+
+    #: Used by:
+    #:
+    #:  - ``FT.AGGREGATE``
+    #:  - ``FT.HYBRID``
+    LIMIT_TOKEN = b"LIMIT"
 
     #: Used by:
     #:
@@ -1434,7 +1406,13 @@ class PureToken(CaseAndEncodingInsensitiveEnum):
     #:
     #:  - ``FT.AGGREGATE``
     #:  - ``FT.HYBRID``
-    REDUCE = b"REDUCE"
+    REDUCE_TOKEN = b"REDUCE"
+
+    #: Used by:
+    #:
+    #:  - ``FT.AGGREGATE``
+    #:  - ``FT.HYBRID``
+    SORTBY_TOKEN = b"SORTBY"
 
     #: Used by:
     #:
@@ -1570,7 +1548,6 @@ class PrefixToken(CaseAndEncodingInsensitiveEnum):
     #: Used by:
     #:
     #:  - ``BITFIELD``
-    #:  - ``INCREX``
     OVERFLOW = b"OVERFLOW"
 
     #: Used by:
@@ -1894,6 +1871,8 @@ class PrefixToken(CaseAndEncodingInsensitiveEnum):
 
     #: Used by:
     #:
+    #:  - ``FT.AGGREGATE``
+    #:  - ``FT.HYBRID``
     #:  - ``FT.SEARCH``
     #:  - ``HEXPIRE``
     #:  - ``HEXPIREAT``

--- a/docs/source/compatibility.rst
+++ b/docs/source/compatibility.rst
@@ -14,184 +14,334 @@ Array
 
 
 
-ARCOUNT [X]
-***********
+ARCOUNT
+*******
 
 Returns the number of non-empty elements in an array.
 
 - Documentation: `ARCOUNT <https://redis.io/commands/arcount>`_
+- Implementation: :meth:`~coredis.Redis.arcount`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARDEL [X]
-*********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARDEL
+*****
 
 Deletes elements at the specified indices in an array.
 
 - Documentation: `ARDEL <https://redis.io/commands/ardel>`_
+- Implementation: :meth:`~coredis.Redis.ardel`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARDELRANGE [X]
-**************
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARDELRANGE
+**********
 
 Deletes elements in one or more ranges.
 
 - Documentation: `ARDELRANGE <https://redis.io/commands/ardelrange>`_
+- Implementation: :meth:`~coredis.Redis.ardelrange`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARGET [X]
-*********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARGET
+*****
 
 Gets the value at an index in an array.
 
 - Documentation: `ARGET <https://redis.io/commands/arget>`_
+- Implementation: :meth:`~coredis.Redis.arget`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARGETRANGE [X]
-**************
+
+- .. versionadded:: 6.8.0
+
+
+
+- Supports client caching: yes
+
+
+
+ARGETRANGE
+**********
 
 Gets values in a range of indices.
 
 - Documentation: `ARGETRANGE <https://redis.io/commands/argetrange>`_
+- Implementation: :meth:`~coredis.Redis.argetrange`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARGREP [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+- Supports client caching: yes
+
+
+
+ARGREP
+******
 
 Searches array elements in a range using textual predicates.
 
 - Documentation: `ARGREP <https://redis.io/commands/argrep>`_
+- Implementation: :meth:`~coredis.Redis.argrep`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARINFO [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARINFO
+******
 
 Returns metadata about an array.
 
 - Documentation: `ARINFO <https://redis.io/commands/arinfo>`_
+- Implementation: :meth:`~coredis.Redis.arinfo`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARINSERT [X]
-************
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARINSERT
+********
 
 Inserts one or more values at consecutive indices.
 
 - Documentation: `ARINSERT <https://redis.io/commands/arinsert>`_
+- Implementation: :meth:`~coredis.Redis.arinsert`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARLASTITEMS [X]
-***************
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARLASTITEMS
+***********
 
 Returns the most recently inserted elements.
 
 - Documentation: `ARLASTITEMS <https://redis.io/commands/arlastitems>`_
+- Implementation: :meth:`~coredis.Redis.arlastitems`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARLEN [X]
-*********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARLEN
+*****
 
 Returns the length of an array (max index + 1).
 
 - Documentation: `ARLEN <https://redis.io/commands/arlen>`_
+- Implementation: :meth:`~coredis.Redis.arlen`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARMGET [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARMGET
+******
 
 Gets values at multiple indices in an array.
 
 - Documentation: `ARMGET <https://redis.io/commands/armget>`_
+- Implementation: :meth:`~coredis.Redis.armget`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARMSET [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+- Supports client caching: yes
+
+
+
+ARMSET
+******
 
 Sets multiple index-value pairs in an array.
 
 - Documentation: `ARMSET <https://redis.io/commands/armset>`_
+- Implementation: :meth:`~coredis.Redis.armset`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARNEXT [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARNEXT
+******
 
 Returns the next index ARINSERT would use.
 
 - Documentation: `ARNEXT <https://redis.io/commands/arnext>`_
+- Implementation: :meth:`~coredis.Redis.arnext`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-AROP [X]
-********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+AROP
+****
 
 Performs aggregate operations on array elements in a range.
 
 - Documentation: `AROP <https://redis.io/commands/arop>`_
+- Implementation: :meth:`~coredis.Redis.arop`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARRING [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARRING
+******
 
 Inserts values into a ring buffer of specified size, wrapping and truncating as needed.
 
 - Documentation: `ARRING <https://redis.io/commands/arring>`_
+- Implementation: :meth:`~coredis.Redis.arring`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARSCAN [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARSCAN
+******
 
 Iterates existing elements in a range, returning index-value pairs.
 
 - Documentation: `ARSCAN <https://redis.io/commands/arscan>`_
+- Implementation: :meth:`~coredis.Redis.arscan`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARSEEK [X]
-**********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARSEEK
+******
 
 Sets the ARINSERT / ARRING cursor to a specific index.
 
 - Documentation: `ARSEEK <https://redis.io/commands/arseek>`_
+- Implementation: :meth:`~coredis.Redis.arseek`
 
-- Not Implemented
+- New in redis: 8.8.0
 
 
-ARSET [X]
-*********
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
+ARSET
+*****
 
 Sets one or more contiguous values starting at an index in an array.
 
 - Documentation: `ARSET <https://redis.io/commands/arset>`_
+- Implementation: :meth:`~coredis.Redis.arset`
 
-- Not Implemented
+- New in redis: 8.8.0
+
+
+
+- .. versionadded:: 6.8.0
+
+
+
 
 
 
@@ -880,6 +1030,24 @@ Increment the floating point value of a key by a number. Uses 0 as initial value
 
 
 
+INCREX
+******
+
+Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.
+
+- Documentation: `INCREX <https://redis.io/commands/increx>`_
+- Implementation: :meth:`~coredis.Redis.increx`
+
+- New in redis: 8.8.0
+
+
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
 LCS
 ***
 
@@ -1064,16 +1232,6 @@ Returns a substring from a string value.
 
 - Supports client caching: yes
 
-
-
-INCREX [X]
-**********
-
-Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.
-
-- Documentation: `INCREX <https://redis.io/commands/increx>`_
-
-- Not Implemented
 
 
 
@@ -3256,6 +3414,24 @@ Return the number of messages in a stream.
 
 
 
+XNACK
+*****
+
+Releases claimed messages back to the group's PEL without acknowledging them, making them available for re-delivery.
+
+- Documentation: `XNACK <https://redis.io/commands/xnack>`_
+- Implementation: :meth:`~coredis.Redis.xnack`
+
+- New in redis: 8.8.0
+
+
+
+- .. versionadded:: 6.8.0
+
+
+
+
+
 XPENDING
 ********
 
@@ -3346,16 +3522,6 @@ XIDMPRECORD [X]
 An internal command for setting IDMP metadata on an existing stream message.
 
 - Documentation: `XIDMPRECORD <https://redis.io/commands/xidmprecord>`_
-
-- Not Implemented
-
-
-XNACK [X]
-*********
-
-Releases claimed messages back to the group's PEL without acknowledging them, making them available for re-delivery.
-
-- Documentation: `XNACK <https://redis.io/commands/xnack>`_
 
 - Not Implemented
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ except:
 
 master_doc = "index"
 project = "coredis"
-copyright = "2107, NoneGG | 2023, Ali-Akber Saifee"
+copyright = "2017, NoneGG | 2023, Ali-Akber Saifee"
 author = "alisaifee"
 description = "Async redis client for python"
 
@@ -173,6 +173,7 @@ cmd_group_order = [
     coredis.commands.constants.CommandGroup.SERVER,
     coredis.commands.constants.CommandGroup.CLUSTER,
     coredis.commands.constants.CommandGroup.CONNECTION,
+    coredis.commands.constants.CommandGroup.ARRAY,
 ]
 preferred_order = {
     "object": 80,

--- a/scripts/RedisJSON.json
+++ b/scripts/RedisJSON.json
@@ -134,6 +134,39 @@
           }
         ],
         "optional": true
+      },
+      {
+        "name": "fpha",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "fpha-type",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "FP16",
+                "type": "pure-token",
+                "token": "FP16"
+              },
+              {
+                "name": "BF16",
+                "type": "pure-token",
+                "token": "BF16"
+              },
+              {
+                "name": "FP32",
+                "type": "pure-token",
+                "token": "FP32"
+              },
+              {
+                "name": "FP64",
+                "type": "pure-token",
+                "token": "FP64"
+              }
+            ]
+          }
+        ],
+        "optional": true
       }
     ],
     "since": "1.0.0",

--- a/scripts/commands.json
+++ b/scripts/commands.json
@@ -10674,31 +10674,12 @@
                 ]
             },
             {
-                "name": "overflow-block",
-                "type": "oneof",
-                "token": "OVERFLOW",
-                "summary": "Out-of-bounds policy; defaults to FAIL. Missing LBOUND/UBOUND default to the type limits (LLONG_MIN/LLONG_MAX for BYINT, -LDBL_MAX/LDBL_MAX for BYFLOAT).",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "fail",
-                        "type": "pure-token",
-                        "display_text": "fail",
-                        "token": "FAIL"
-                    },
-                    {
-                        "name": "sat",
-                        "type": "pure-token",
-                        "display_text": "sat",
-                        "token": "SAT"
-                    },
-                    {
-                        "name": "reject",
-                        "type": "pure-token",
-                        "display_text": "reject",
-                        "token": "REJECT"
-                    }
-                ]
+                "name": "saturate",
+                "type": "pure-token",
+                "display_text": "saturate",
+                "token": "SATURATE",
+                "summary": "Saturate the result to LBOUND/UBOUND (or the type limits when no explicit bound is given) when out of bounds. Without this option, out-of-bounds operations are rejected and reply [current_value, 0].",
+                "optional": true
             },
             {
                 "name": "lowerbound",

--- a/scripts/search.json
+++ b/scripts/search.json
@@ -470,6 +470,19 @@
     "since": "1.0.0",
     "group": "search"
   },
+  "FT.ALIASLIST": {
+    "summary": "Lists all aliases for the index",
+    "complexity": "O(N) where N is the number of aliases",
+    "arguments": [
+      {
+        "name": "index",
+        "type": "string",
+        "summary": "Specifies the name of the index. The index must be created using `FT.CREATE`."
+      }
+    ],
+    "since": "8.10.0",
+    "group": "search"
+  },
   "FT.TAGVALS": {
     "summary": "Returns the distinct tags indexed in a Tag field",
     "complexity": "O(N)",
@@ -1328,84 +1341,203 @@
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "token": "REDUCE",
-                "type": "pure-token"
+                "name": "reduce_token",
+                "type": "pure-token",
+                "token": "REDUCE"
               },
               {
-                "name": "function",
+                "name": "reducer_body",
                 "type": "oneof",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "generic_body",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "function",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
+                          },
+                          {
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "fields",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
               },
               {
                 "name": "name",
@@ -1413,8 +1545,7 @@
                 "token": "AS",
                 "optional": true
               }
-            ],
-            "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results."
+            ]
           }
         ],
         "summary": "Groups results by specified fields, often used for aggregations."
@@ -2404,84 +2535,203 @@
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
+                "name": "reduce_token",
                 "type": "pure-token",
                 "token": "REDUCE"
               },
               {
-                "name": "function",
+                "name": "reducer_body",
                 "type": "oneof",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "generic_body",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "function",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
+                          },
+                          {
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "fields",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
               },
               {
                 "name": "name",

--- a/scripts/suggestion.json
+++ b/scripts/suggestion.json
@@ -470,6 +470,19 @@
     "since": "1.0.0",
     "group": "search"
   },
+  "FT.ALIASLIST": {
+    "summary": "Lists all aliases for the index",
+    "complexity": "O(N) where N is the number of aliases",
+    "arguments": [
+      {
+        "name": "index",
+        "type": "string",
+        "summary": "Specifies the name of the index. The index must be created using `FT.CREATE`."
+      }
+    ],
+    "since": "8.10.0",
+    "group": "search"
+  },
   "FT.TAGVALS": {
     "summary": "Returns the distinct tags indexed in a Tag field",
     "complexity": "O(N)",
@@ -1328,84 +1341,203 @@
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "token": "REDUCE",
-                "type": "pure-token"
+                "name": "reduce_token",
+                "type": "pure-token",
+                "token": "REDUCE"
               },
               {
-                "name": "function",
+                "name": "reducer_body",
                 "type": "oneof",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "generic_body",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "function",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
+                          },
+                          {
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "fields",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
               },
               {
                 "name": "name",
@@ -1413,8 +1545,7 @@
                 "token": "AS",
                 "optional": true
               }
-            ],
-            "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results."
+            ]
           }
         ],
         "summary": "Groups results by specified fields, often used for aggregations."
@@ -2404,84 +2535,203 @@
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
+                "name": "reduce_token",
                 "type": "pure-token",
                 "token": "REDUCE"
               },
               {
-                "name": "function",
+                "name": "reducer_body",
                 "type": "oneof",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "generic_body",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "function",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "count",
+                            "type": "pure-token",
+                            "token": "COUNT"
+                          },
+                          {
+                            "name": "count_distinct",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCT"
+                          },
+                          {
+                            "name": "count_distinctish",
+                            "type": "pure-token",
+                            "token": "COUNT_DISTINCTISH"
+                          },
+                          {
+                            "name": "sum",
+                            "type": "pure-token",
+                            "token": "SUM"
+                          },
+                          {
+                            "name": "min",
+                            "type": "pure-token",
+                            "token": "MIN"
+                          },
+                          {
+                            "name": "max",
+                            "type": "pure-token",
+                            "token": "MAX"
+                          },
+                          {
+                            "name": "avg",
+                            "type": "pure-token",
+                            "token": "AVG"
+                          },
+                          {
+                            "name": "stddev",
+                            "type": "pure-token",
+                            "token": "STDDEV"
+                          },
+                          {
+                            "name": "quantile",
+                            "type": "pure-token",
+                            "token": "QUANTILE"
+                          },
+                          {
+                            "name": "tolist",
+                            "type": "pure-token",
+                            "token": "TOLIST"
+                          },
+                          {
+                            "name": "first_value",
+                            "type": "pure-token",
+                            "token": "FIRST_VALUE"
+                          },
+                          {
+                            "name": "random_sample",
+                            "type": "pure-token",
+                            "token": "RANDOM_SAMPLE"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "arg",
+                        "type": "string",
+                        "multiple": true
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
-                  },
-                  {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
-                  },
-                  {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
-                  },
-                  {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "collect_body",
+                    "type": "block",
+                    "since": "8.8.0",
+                    "arguments": [
+                      {
+                        "name": "collect_token",
+                        "type": "pure-token",
+                        "token": "COLLECT"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "fields_clause",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "fields",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer",
+                                "token": "FIELDS"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          },
+                          {
+                            "name": "fieldsall",
+                            "type": "pure-token",
+                            "token": "FIELDS *"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "sortby",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "sortby_token",
+                            "type": "pure-token",
+                            "token": "SORTBY"
+                          },
+                          {
+                            "name": "nargs",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "key",
+                            "type": "block",
+                            "multiple": true,
+                            "arguments": [
+                              {
+                                "name": "field",
+                                "type": "string"
+                              },
+                              {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                  {
+                                    "name": "asc",
+                                    "type": "pure-token",
+                                    "token": "ASC"
+                                  },
+                                  {
+                                    "name": "desc",
+                                    "type": "pure-token",
+                                    "token": "DESC"
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "name": "limit",
+                        "type": "block",
+                        "optional": true,
+                        "arguments": [
+                          {
+                            "name": "limit_token",
+                            "type": "pure-token",
+                            "token": "LIMIT"
+                          },
+                          {
+                            "name": "offset",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "count",
+                            "type": "integer"
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
-              },
-              {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
               },
               {
                 "name": "name",

--- a/scripts/timeseries.json
+++ b/scripts/timeseries.json
@@ -635,89 +635,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -810,89 +730,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -1041,89 +881,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -1298,89 +1058,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -1477,6 +1157,37 @@
             }
         ],
         "since": "1.0.0",
+        "group": "timeseries"
+    },
+    "TS.BGET": {
+        "summary": "Blocking GET: wait up to `timeout` milliseconds and retrieve up to `count` samples with timestamp >= `timestamp`. Returns the oldest qualifying samples in ascending timestamp order. When `timeout` is 0 the command does not block and returns whatever is available now (possibly empty or fewer than `count`).",
+        "complexity": "O(log(n)+k) where n is the number of samples in the series and k is the number of returned samples",
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key"
+            },
+            {
+                "name": "timestamp",
+                "type": "string"
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "timeout",
+                "type": "integer"
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "blocking"
+        ],
+        "acl_categories": [
+            "read"
+        ],
+        "since": "8.10.0",
         "group": "timeseries"
     },
     "TS.MGET": {

--- a/tests/commands/test_array.py
+++ b/tests/commands/test_array.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import pytest
+
+from coredis.commands.core import Predicate
+from coredis.exceptions import DataError
+from coredis.tokens import PureToken
+from tests.conftest import targets
+
+
+@targets(
+    "redis_basic",
+    "redis_basic_raw",
+    "redis_cluster",
+    "redis_cluster_raw",
+    "redis_cached",
+    "redis_cluster_cached",
+    "dragonfly",
+    "valkey",
+)
+@pytest.mark.min_server_version("8.8.0")
+class TestArray:
+    async def test_arcount(self, client, _s):
+        assert await client.arcount("arr") == 0
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arcount("arr") == 3
+
+    async def test_arset(self, client, _s):
+        assert await client.arcount("arr") == 0
+        assert await client.arset("arr", 0, ["a", "b", "c"]) == 3
+        assert await client.arcount("arr") == 3
+
+    async def test_ardel(self, client, _s):
+        assert await client.arcount("arr") == 0
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arcount("arr") == 3
+        assert await client.ardel("arr", [0, 1, 2]) == 3
+        assert await client.arcount("arr") == 0
+
+    async def test_ardelrange(self, client, _s):
+        assert await client.arcount("arr") == 0
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arcount("arr") == 3
+        assert await client.ardelrange("arr", [(0, 2)]) == 3
+        assert await client.arcount("arr") == 0
+        with pytest.raises(DataError):
+            await client.ardelrange("arr", [])
+
+    async def test_arget(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arget("arr", 0) == _s("a")
+        assert await client.arget("arr", 4) is None
+
+    async def test_argetrange(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.argetrange("arr", 0, 2) == [_s("a"), _s("b"), _s("c")]
+
+    async def test_argrep(self, client, _s):
+        await client.arinsert("arr", ["ab", "bc", "cd"])
+        pred = Predicate(match="b") | Predicate(exact="cd")
+        assert await client.argrep("arr", 0, 2, pred) == [0, 1, 2]
+        pred = Predicate(glob="b*") & Predicate(re=r"[a-z]+")
+        assert await client.argrep("arr", 0, 2, pred) == [1]
+        pred = Predicate(match="B")
+        assert await client.argrep("arr", 0, 2, pred, limit=1, nocase=True) == [0]
+        pred = Predicate(match="b")
+        assert await client.argrep("arr", 0, 1, pred, withvalues=True) == [
+            (0, _s("ab")),
+            (1, _s("bc")),
+        ]
+
+    async def test_arinfo(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert (await client.arinfo("arr"))[_s("count")] == 3
+        assert _s("avg-sparse-size") in await client.arinfo("arr", full=True)
+
+    async def test_arinsert_seek_next(self, client, _s):
+        assert await client.arset("arr", 0, ["a", "b", "c"]) == 3
+        assert await client.arnext("arr") == 0
+        assert await client.arseek("arr", 1)
+        assert await client.arinsert("arr", ["d", "e", "f"]) == 3
+        assert await client.argetrange("arr", 0, 3) == [_s("a"), _s("d"), _s("e"), _s("f")]
+        assert await client.arnext("arr") == 4
+
+    async def test_arlastitems(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        await client.arset("arr", 3, ["d", "e", "f"])
+        assert await client.arlastitems("arr", 2, rev=True) == (_s("c"), _s("b"))
+
+    async def test_arlen(self, client, _s):
+        assert await client.arlen("arr") == await client.arcount("arr") == 0
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arlen("arr") == await client.arcount("arr") == 3
+        await client.ardel("arr", [1])
+        assert await client.arcount("arr") == 2
+        assert await client.arlen("arr") == 3
+
+    async def test_armget(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.armget("arr", [0, 3]) == (_s("a"), None)
+
+    async def test_armset(self, client, _s):
+        assert await client.armset("arr", {0: "a", 2: "c"}) == 2
+        assert await client.argetrange("arr", 0, 2) == [_s("a"), None, _s("c")]
+
+    async def test_arring(self, client, _s):
+        assert await client.arring("arr", 3, ["a", "b", "c"]) == 2
+        assert await client.arring("arr", 3, ["d"]) == 0
+        assert await client.argetrange("arr", 0, 2) == [_s("d"), _s("b"), _s("c")]
+
+    async def test_arop(self, client, _s):
+        await client.arinsert("arr", ["a", 100, 200, 300])
+        assert await client.arop("arr", 0, 3, match="a") == 1
+        assert await client.arop("arr", 0, 3, op=PureToken.SUM) == 600
+        assert await client.arop("arr", 0, 3, op=PureToken.MAX) == 300
+        assert await client.arop("arr", 0, 3, op=PureToken.MIN) == 100
+        assert await client.arop("arr", 0, 3, op=PureToken.AND) == 0
+        assert await client.arop("arr", 0, 3, op=PureToken.OR) == 492
+        assert await client.arop("arr", 0, 3, op=PureToken.XOR) == 384
+
+    async def test_arscan(self, client, _s):
+        await client.arinsert("arr", ["a", "b", "c"])
+        assert await client.arscan("arr", 0, 2, limit=2) == [(0, _s("a")), (1, _s("b"))]

--- a/tests/commands/test_streams.py
+++ b/tests/commands/test_streams.py
@@ -589,3 +589,40 @@ class TestStreams:
         )
         assert await client.xcfgset("test", idmp_maxsize=1)
         assert new_identifier != await client.xadd("test", {"fu": 1}, idmpauto="producer1")
+
+    @pytest.mark.min_server_version("8.8")
+    async def test_xnack(self, client, _s):
+        ids = []
+        for i in range(4):
+            ids.append(await client.xadd("test_stream", {"k1": i}))
+
+        await client.xgroup_create("test_stream", "group", "0")
+        await client.xreadgroup("group", "consumer", {"test_stream": ">"})
+
+        # after delivery every message has a delivery counter of 1
+        detail = await client.xpending("test_stream", "group", start="-", end="+", count=10)
+        assert all(e.delivered == 1 for e in detail)
+
+        # SILENT decrements the counter, FAIL leaves it, FATAL maxes it out
+        assert await client.xnack("test_stream", "group", PureToken.SILENT, [ids[0]]) == 1
+        assert await client.xnack("test_stream", "group", PureToken.FAIL, [ids[1]]) == 1
+        assert await client.xnack("test_stream", "group", PureToken.FATAL, [ids[2]]) == 1
+
+        # messages remain pending — XNACK never acknowledges
+        assert (await client.xpending("test_stream", "group")).pending == 4
+        counters = {
+            e.identifier: e.delivered
+            for e in await client.xpending("test_stream", "group", start="-", end="+", count=10)
+        }
+        assert counters[ids[0]] == 0
+        assert counters[ids[1]] == 1
+        assert counters[ids[2]] == 9223372036854775807
+        # RETRYCOUNT sets the delivery counter explicitly
+        assert (
+            await client.xnack("test_stream", "group", PureToken.FAIL, [ids[3]], retrycount=7) == 1
+        )
+        counters = {
+            e.identifier: e.delivered
+            for e in await client.xpending("test_stream", "group", start="-", end="+", count=10)
+        }
+        assert counters[ids[3]] == 7

--- a/tests/commands/test_string.py
+++ b/tests/commands/test_string.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 
+import anyio
 import pytest
 
 from coredis import PureToken
@@ -54,6 +55,40 @@ class TestString:
         assert await client.get("a") == _s("1")
         assert await client.incrbyfloat("a", 1.1) == 2.1
         assert float(await client.get("a")) == 2.1
+
+    @pytest.mark.min_server_version("8.8.0")
+    async def test_increx(self, client, _s):
+        # missing key starts at 0 and increments by 1 in integer mode
+        assert await client.increx("a") == (1, 1)
+        assert await client.increx("a") == (2, 1)
+        # BYINT with positive and negative increments
+        await client.set("b", 100)
+        assert await client.increx("b", increment=5) == (105, 5)
+        assert await client.increx("b", increment=-10) == (95, -10)
+        # a float increment selects BYFLOAT mode
+        await client.set("c", "1.5")
+        new, delta = await client.increx("c", increment=0.25)
+        assert (float(new), float(delta)) == (1.75, 0.25)
+        # EX sets a TTL alongside the increment
+        for i in range(5):
+            assert await client.increx("d", upperbound=5, ex=1, enx=True) == (i + 1, 1)
+        for i in range(5):
+            assert await client.increx("d", upperbound=5, ex=1, enx=True) == (5, 0)
+        # should reset window
+        await anyio.sleep(1)
+        assert await client.increx("d", upperbound=5, ex=1, enx=True) == (1, 1)
+        # PERSIST clears the TTL while incrementing
+        await client.set("f", 5, ex=1000)
+        assert await client.increx("f", persist=True) == (6, 1)
+        assert await client.ttl("f") == -1
+        # SATURATE caps at the bound and reports the applied delta
+        await client.set("g", 99)
+        assert await client.increx("g", increment=5, upperbound=100, saturate=True) == (100, 1)
+        assert await client.get("g") == _s("100")
+        # lower bound: skipped by default, floored with SATURATE
+        await client.set("h", 5)
+        assert await client.increx("h", increment=-10, lowerbound=0) == (5, 0)
+        assert await client.increx("h", increment=-10, lowerbound=0, saturate=True) == (0, -5)
 
     async def test_getrange(self, client, _s):
         await client.set("a", "foo")


### PR DESCRIPTION
## Description
Decided to take a stab at adding some of the new commands from Redis 8.8. Most of these are related to the new array data type. Had to re-run the code gen script since a few tokens changed right at release.

## Command checklist
* [x] ARCOUNT
* [x] ARDEL
* [x] ARDELRANGE
* [x] ARGET
* [x] ARGETRANGE
* [x] ARGREP
* [x] ARINFO
* [x] ARINSERT
* [x] ARLASTITEMS
* [x] ARLEN
* [x] ARMGET
* [x] ARMSET
* [x] ARNEXT
* [x] AROP
* [x] ARRING
* [x] ARSCAN
* [x] ARSEEK
* [x] ARSET
* [x] INCREX
* [x] XNACK

## Modified commands
* [x] ZINTER/ZUNION changes
* [x] JSON.SET changes
* [x] TS.RANGE/TS.REVRANGE changes
* [x] FT.HYBRID: new option for KNN, SHARD_K_RATIO
* [ ] ~FT.PROFILE: new argument, HYBRID~ looks like FT.PROFILE isn't implemented? probably fine as we're missing a lot of profiling commands, but that stuff can be done via CLI usually

## Pre-merge checklist
- [x] Code formatted correctly
- [x] Passing tests locally
- [x] New tests added (if applicable)
- [x] Docs updated (if applicable)
