### PR TITLE
Add `supports` method to base client

### DIFF
--- a/coredis/client/basic.py
+++ b/coredis/client/basic.py
@@ -116,6 +116,7 @@ class Client(
         self.server_version: Version | None = None
         self.verify_version = verify_version
         self.__noreply = noreply
+        self._supported: dict[CommandName, bool] = {}
         self._noreplycontext: contextvars.ContextVar[bool | None] = contextvars.ContextVar(
             "noreply", default=None
         )
@@ -354,6 +355,19 @@ class Client(
         :param name: name of the library
         """
         return await Library[AnyStr](self, name)
+
+    @versionadded(version="6.8.0")
+    async def supports(self, command: CommandName) -> bool:
+        """
+        Check if given command is supported by the server. Result is cached.
+
+        :param command: command name to check
+        """
+        supported = self._supported.get(command)
+        if supported is None:
+            supported = bool(await self.command_info(command))
+            self._supported[command] = supported
+        return supported
 
     @contextlib.contextmanager
     def ignore_replies(self: ClientT) -> Iterator[ClientT]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from anyio import create_task_group, fail_after, sleep
 from packaging.version import Version
 
 import coredis
+from coredis.commands.constants import CommandName
 from coredis.exceptions import (
     AuthorizationError,
     ConnectionError,
@@ -120,6 +121,9 @@ class TestClient:
     async def test_stream_timeout(self, client, client_arguments, _s):
         with pytest.raises(TimeoutError):
             await client.hset("hash", {bytes(k): k for k in range(4096)})
+
+    async def test_supports(self, client):
+        assert await client.supports(CommandName.GET)
 
 
 @targets(


### PR DESCRIPTION
Motivation: Currently, to check if the server supports a command is very unwieldy and requires pre-warming the connection and checking the server version. This commit adds a convenience method, `Client.supports()`, to check commands quickly for support. Though it requires a round trip since under the hood it uses COMMAND INFO, the result is cached so it's only slow on the first call.

Right now to check for command support you'd need to do something like:
```python
await client.ping()
if client.server_version and client.server_version >= Version("8.8.0"):
    print("INCREX supported!")
```

With this change you can simply do:
```python
if await client.supports(CommandName.INCREX):
    print("INCREX supported!")
```
